### PR TITLE
Fix optimistic update for Sentry Mode and address test TODOs

### DIFF
--- a/custom_components/zeekr_ev/switch.py
+++ b/custom_components/zeekr_ev/switch.py
@@ -221,6 +221,9 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
                     self._update_local_state_optimistically(is_on=False)
                 self.async_write_ha_state()
             elif self.field == "sentry_mode":
+                self._update_local_state_optimistically(is_on=True)
+                self.async_write_ha_state()
+
                 async def delayed_refresh():
                     await asyncio.sleep(10)
                     await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Implemented optimistic state update for Sentry Mode in `async_turn_on` to match `async_turn_off` behavior. Also updated `tests/test_switch.py` to assert this behavior and implemented the missing test case for turning on charging.

---
*PR created automatically by Jules for task [13447778173063278243](https://jules.google.com/task/13447778173063278243)*