### PR TITLE
Add last_updated attribute to ZeekrClimate entity

### DIFF
--- a/custom_components/zeekr_ev/climate.py
+++ b/custom_components/zeekr_ev/climate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -169,6 +170,25 @@ class ZeekrClimate(CoordinatorEntity, ClimateEntity):
         # If currently running, update the temp by sending the command again
         if self.hvac_mode == HVACMode.HEAT_COOL:
             await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        attrs = {}
+        try:
+            val = (
+                self.coordinator.data.get(self.vin, {})
+                .get("additionalVehicleStatus", {})
+                .get("climateStatus", {})
+                .get("updateTime")
+            )
+            if val is not None:
+                # Convert milliseconds to datetime
+                dt = datetime.fromtimestamp(int(val) / 1000, tz=timezone.utc)
+                attrs["last_updated"] = dt.isoformat()
+        except (ValueError, TypeError, AttributeError):
+            pass
+        return attrs
 
     @property
     def device_info(self):

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -81,6 +81,7 @@ async def test_climate_optimistic_update():
 
     # Verify Delayed Refresh Task Created
     assert climate.hass.async_create_task.called
+    climate.hass.async_create_task.call_args[0][0].close()
 
     # Test Turn Off
     await climate.async_set_hvac_mode(HVACMode.OFF)
@@ -106,6 +107,7 @@ async def test_climate_optimistic_update():
 
     # Verify Delayed Refresh Task Created again
     assert climate.hass.async_create_task.call_count == 2
+    climate.hass.async_create_task.call_args[0][0].close()
 
 
 @pytest.mark.asyncio
@@ -136,3 +138,38 @@ async def test_climate_async_setup_entry(hass, mock_config_entry):
     # Check types
     types = [type(e) for e in async_add_entities.call_args[0][0]]
     assert ZeekrClimate in types
+
+
+@pytest.mark.asyncio
+async def test_climate_attributes(hass):
+    vin = "VIN1"
+    # Example timestamp from user: 1763418526287
+    # 2025-11-17 22:28:46.287 UTC
+    update_time_ms = 1763418526287
+    expected_iso = "2025-11-17T22:28:46.287000+00:00"
+
+    initial_data = {
+        vin: {
+            "additionalVehicleStatus": {
+                "climateStatus": {
+                    "updateTime": update_time_ms
+                }
+            }
+        }
+    }
+
+    coordinator = MockCoordinator(initial_data)
+    climate = ZeekrClimate(coordinator, vin)
+
+    attrs = climate.extra_state_attributes
+    assert attrs["last_updated"] == expected_iso
+
+    # Test missing updateTime
+    initial_data[vin]["additionalVehicleStatus"]["climateStatus"].pop("updateTime")
+    attrs = climate.extra_state_attributes
+    assert "last_updated" not in attrs
+
+    # Test invalid updateTime
+    initial_data[vin]["additionalVehicleStatus"]["climateStatus"]["updateTime"] = "invalid"
+    attrs = climate.extra_state_attributes
+    assert "last_updated" not in attrs


### PR DESCRIPTION
Implemented `extra_state_attributes` in `ZeekrClimate` to parse `updateTime` (milliseconds) from `climateStatus`.
Added unit tests in `tests/test_climate.py` to verify the attribute is present and correctly formatted.
Fixed `RuntimeWarning` in existing climate tests by properly closing mocked coroutines.

---
*PR created automatically by Jules for task [11546333860786889106](https://jules.google.com/task/11546333860786889106)*