### PR TITLE
Fix entity naming for multi-car support

### DIFF
--- a/custom_components/zeekr_ev/binary_sensor.py
+++ b/custom_components/zeekr_ev/binary_sensor.py
@@ -18,6 +18,8 @@ from .coordinator import ZeekrCoordinator
 class ZeekrBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Zeekr Binary Sensor class."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: ZeekrCoordinator,
@@ -31,7 +33,7 @@ class ZeekrBinarySensor(CoordinatorEntity, BinarySensorEntity):
         super().__init__(coordinator)
         self.vin = vin
         self.key = key
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} {name}"
+        self._attr_name = name
         self._attr_unique_id = f"{vin}_{key}"
         self._value_fn = value_fn
         self._attr_device_class = device_class

--- a/custom_components/zeekr_ev/cover.py
+++ b/custom_components/zeekr_ev/cover.py
@@ -41,6 +41,7 @@ async def async_setup_entry(
 class ZeekrSunshade(CoordinatorEntity, CoverEntity):
     """Zeekr Sunshade class."""
 
+    _attr_has_entity_name = True
     _attr_device_class = CoverDeviceClass.BLIND
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
@@ -48,7 +49,7 @@ class ZeekrSunshade(CoordinatorEntity, CoverEntity):
         """Initialize the cover entity."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Sunshade"
+        self._attr_name = "Sunshade"
         self._attr_unique_id = f"{vin}_sunshade"
 
     @property
@@ -167,6 +168,7 @@ class ZeekrSunshade(CoordinatorEntity, CoverEntity):
 class ZeekrWindows(CoordinatorEntity, CoverEntity):
     """Zeekr Windows class (controls all windows)."""
 
+    _attr_has_entity_name = True
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
@@ -174,7 +176,7 @@ class ZeekrWindows(CoordinatorEntity, CoverEntity):
         """Initialize the cover entity."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} All Windows"
+        self._attr_name = "All Windows"
         self._attr_unique_id = f"{vin}_all_windows"
 
     @property
@@ -302,6 +304,7 @@ class ZeekrWindows(CoordinatorEntity, CoverEntity):
 class ZeekrWindow(CoordinatorEntity, CoverEntity):
     """Zeekr Window (Read-Only) class."""
 
+    _attr_has_entity_name = True
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_supported_features = CoverEntityFeature(0)
 
@@ -310,7 +313,7 @@ class ZeekrWindow(CoordinatorEntity, CoverEntity):
         super().__init__(coordinator)
         self.vin = vin
         self.win_key = win_key
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} {win_name}"
+        self._attr_name = win_name
         self._attr_unique_id = f"{vin}_window_{win_key.lower()}"
 
     @property

--- a/custom_components/zeekr_ev/device_tracker.py
+++ b/custom_components/zeekr_ev/device_tracker.py
@@ -31,11 +31,13 @@ async def async_setup_entry(
 class ZeekrDeviceTracker(CoordinatorEntity, TrackerEntity):
     """Zeekr Device Tracker."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
         """Initialize the tracker."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Location"
+        self._attr_name = "Location"
         self._attr_unique_id = f"{vin}_location"
 
     @property

--- a/custom_components/zeekr_ev/entity.py
+++ b/custom_components/zeekr_ev/entity.py
@@ -15,6 +15,8 @@ _LOGGER = logging.getLogger(__name__)
 class ZeekrEntity(CoordinatorEntity[ZeekrCoordinator]):
     """Base entity for Zeekr."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
         """Initialize."""
         super().__init__(coordinator)

--- a/custom_components/zeekr_ev/lock.py
+++ b/custom_components/zeekr_ev/lock.py
@@ -51,6 +51,8 @@ async def async_setup_entry(
 class ZeekrLock(CoordinatorEntity, LockEntity):
     """Zeekr Lock class representing various latch/lock states."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: ZeekrCoordinator,
@@ -64,7 +66,7 @@ class ZeekrLock(CoordinatorEntity, LockEntity):
         self.vin = vin
         self.field = field
         self.category = category
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} {label}"
+        self._attr_name = label
         self._attr_unique_id = f"{vin}_{field}"
 
     @property

--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -361,6 +361,8 @@ async def async_setup_entry(
 class ZeekrSensor(CoordinatorEntity, SensorEntity):
     """Zeekr Sensor class."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: ZeekrCoordinator,
@@ -376,7 +378,7 @@ class ZeekrSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self.vin = vin
         self.key = key
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} {name}"
+        self._attr_name = name
         self._attr_unique_id = f"{vin}_{key}"
         self._value_fn = value_fn
         self._attr_native_unit_of_measurement = unit
@@ -508,11 +510,13 @@ class ZeekrAPIStatSensor(CoordinatorEntity, SensorEntity):
 class ZeekrChargingTimeFormattedSensor(CoordinatorEntity, SensorEntity):
     """Sensor for formatted display of charging time remaining (e.g., 2h 53m)."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Charging Time Remaining"
+        self._attr_name = "Charging Time Remaining"
         self._attr_unique_id = f"{vin}_charging_time_formatted"
         self._attr_icon = "mdi:timer-sand"
 
@@ -558,6 +562,8 @@ class ZeekrChargingTimeFormattedSensor(CoordinatorEntity, SensorEntity):
 class ZeekrVehicleStatusSensor(CoordinatorEntity, SensorEntity):
     """Sensor for vehicle usage mode / status."""
 
+    _attr_has_entity_name = True
+
     _STATUS_MAP = {
         "0": "Deep Sleep",
         "1": "Parked",
@@ -571,7 +577,7 @@ class ZeekrVehicleStatusSensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Vehicle Status"
+        self._attr_name = "Vehicle Status"
         self._attr_unique_id = f"{vin}_vehicle_status"
         self._attr_icon = "mdi:car-connected"
 
@@ -599,6 +605,8 @@ class ZeekrVehicleStatusSensor(CoordinatorEntity, SensorEntity):
 class ZeekrEngineStatusSensor(CoordinatorEntity, SensorEntity):
     """Sensor for engine / drive status."""
 
+    _attr_has_entity_name = True
+
     _STATUS_MAP = {
         "engine-off": "Parked",
         "engine-running": "Driving",
@@ -610,7 +618,7 @@ class ZeekrEngineStatusSensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Engine Status"
+        self._attr_name = "Engine Status"
         self._attr_unique_id = f"{vin}_engine_status"
         self._attr_icon = "mdi:car"
 

--- a/custom_components/zeekr_ev/switch.py
+++ b/custom_components/zeekr_ev/switch.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
 class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
     """Zeekr Switch class."""
 
+    _attr_has_entity_name = True
     _attr_icon = "mdi:toggle-switch"
 
     def __init__(
@@ -76,7 +77,7 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
         self.field = field
         self.status_key = status_key or field
         self.status_group = status_group
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} {label}"
+        self._attr_name = label
         self._attr_unique_id = f"{vin}_{field}"
         if field == "charging":
             self._attr_icon = "mdi:battery-off"
@@ -359,7 +360,7 @@ class ZeekrChargingScheduleSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEnt
         """Initialize the charging schedule switch."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Charge Plan"
+        self._attr_name = "Charge Plan"
         self._attr_unique_id = f"{vin}_charging_schedule"
 
     @property
@@ -432,7 +433,7 @@ class ZeekrTravelPlanSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
         """Initialize the travel plan switch."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Travel Plan"
+        self._attr_name = "Travel Plan"
         self._attr_unique_id = f"{vin}_travel_plan"
 
     @property
@@ -506,7 +507,7 @@ class ZeekrDepartureACSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
         """Initialize the departure AC switch."""
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Departure AC"
+        self._attr_name = "Departure AC"
         self._attr_unique_id = f"{vin}_departure_ac"
 
     @property


### PR DESCRIPTION
This refactors the `_attr_name` logic across the entire integration. Rather than hardcoding the VIN prefix into every entity name string (which breaks device renaming in Home Assistant), this correctly utilizes `_attr_has_entity_name = True` and basic names. 

The device association (which has the VIN) provides the context dynamically, allowing full rename support in the UI for users with multiple Zeekrs. Global API sensors were left intact.

---
*PR created automatically by Jules for task [13689426358095610043](https://jules.google.com/task/13689426358095610043)*