### PR TITLE
Implement trunk lock and unlock controls

### DIFF
--- a/custom_components/zeekr_ev/lock.py
+++ b/custom_components/zeekr_ev/lock.py
@@ -141,6 +141,18 @@ class ZeekrLock(CoordinatorEntity, LockEntity):
                     }
                 ]
             }
+        elif self.field == "trunkLockStatus":
+            # Trunk locks automatically, but we can try sending a central lock command
+            command = "start"
+            service_id = "RDL"
+            setting = {
+                "serviceParameters": [
+                    {
+                        "key": "door",
+                        "value": "all"
+                    }
+                ]
+            }
 
         if command and service_id and setting:
             await self.coordinator.async_inc_invoke()
@@ -194,6 +206,17 @@ class ZeekrLock(CoordinatorEntity, LockEntity):
                     }
                 ]
             }
+        elif self.field == "trunkLockStatus":
+            command = "stop"
+            service_id = "RDU"
+            setting = {
+                "serviceParameters": [
+                    {
+                        "key": "target",
+                        "value": "trunk"
+                    }
+                ]
+            }
 
         if command and service_id and setting:
             await self.coordinator.async_inc_invoke()
@@ -227,6 +250,9 @@ class ZeekrLock(CoordinatorEntity, LockEntity):
         elif self.field == "chargeLidDcAcStatus":
             # Locked (Closed)="2", Unlocked (Open)="1"
             status[self.field] = "2" if locked else "1"
+        elif self.field == "trunkLockStatus":
+            # Locked="1", Unlocked="0"
+            status[self.field] = "1" if locked else "0"
 
     @property
     def device_info(self):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -173,6 +173,53 @@ async def test_lock_optimistic_update_charge_lid():
 
 
 @pytest.mark.asyncio
+async def test_lock_optimistic_update_trunk_lock():
+    vin = "VIN1"
+    initial_data = {
+        vin: {
+            "additionalVehicleStatus": {
+                "drivingSafetyStatus": {
+                    "trunkLockStatus": "0"  # Unlocked
+                }
+            }
+        }
+    }
+
+    coordinator = MockCoordinator(initial_data)
+    coordinator.vehicles[vin] = MockVehicle(vin)
+    # mock do_remote_control to verify call arguments
+    coordinator.vehicles[vin].do_remote_control = MagicMock()
+
+    lock = ZeekrLock(coordinator, vin, "trunkLockStatus", "Trunk lock", "drivingSafetyStatus")
+    lock.hass = DummyHass()
+    lock.async_write_ha_state = MagicMock()
+
+    # Test Lock
+    await lock.async_lock()
+
+    # verify central locking was sent
+    coordinator.vehicles[vin].do_remote_control.assert_called_with(
+        "start", "RDL", {"serviceParameters": [{"key": "door", "value": "all"}]}
+    )
+
+    status = coordinator.data[vin]["additionalVehicleStatus"]["drivingSafetyStatus"]
+    assert status["trunkLockStatus"] == "1"
+    lock.async_write_ha_state.assert_called()
+
+    # Test Unlock
+    await lock.async_unlock()
+
+    # verify RDU stop was sent to trunk
+    coordinator.vehicles[vin].do_remote_control.assert_called_with(
+        "stop", "RDU", {"serviceParameters": [{"key": "target", "value": "trunk"}]}
+    )
+
+    status = coordinator.data[vin]["additionalVehicleStatus"]["drivingSafetyStatus"]
+    assert status["trunkLockStatus"] == "0"
+    lock.async_write_ha_state.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_lock_no_vehicle(hass):
     coordinator = MockCoordinator({"VIN1": {}})
     lock = ZeekrLock(coordinator, "VIN1", "centralLockingStatus", "Label", "drivingSafetyStatus")


### PR DESCRIPTION
Adds support for locking and unlocking the trunk via the API. Unlocking specifically targets the trunk, whereas locking triggers a central locking command as a fallback per API constraints. Also adds associated optimistic update logic and unit tests.

---
*PR created automatically by Jules for task [11271761346885257525](https://jules.google.com/task/11271761346885257525)*