### PR TITLE
Add Journey Log sensors (rebase of #55)

### DIFF
--- a/custom_components/zeekr_ev/coordinator.py
+++ b/custom_components/zeekr_ev/coordinator.py
@@ -141,6 +141,18 @@ class ZeekrCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Error fetching travel plan for %s: %s", vehicle.vin, e)
                 return None
 
+        async def fetch_journey_log():
+            if not hasattr(vehicle, "get_journey_log"):
+                return None
+            try:
+                await self.request_stats.async_inc_request()
+                return await self.hass.async_add_executor_job(
+                    lambda: vehicle.get_journey_log(page_size=50)
+                )
+            except Exception as e:
+                _LOGGER.debug("Error fetching journey log for %s: %s", vehicle.vin, e)
+                return None
+
         # Execute parallel tasks
         results = await asyncio.gather(
             fetch_remote_control_state(),
@@ -148,10 +160,11 @@ class ZeekrCoordinator(DataUpdateCoordinator):
             fetch_charging_limit(),
             fetch_charge_plan(),
             fetch_travel_plan(),
+            fetch_journey_log(),
             return_exceptions=True
         )
 
-        remote_state, charging_status, charging_limit, charge_plan, travel_plan = results
+        remote_state, charging_status, charging_limit, charge_plan, travel_plan, journey_log = results
 
         # Process results
         if isinstance(remote_state, dict) and remote_state:
@@ -170,6 +183,9 @@ class ZeekrCoordinator(DataUpdateCoordinator):
 
         if isinstance(travel_plan, dict) and travel_plan:
             vehicle_data["travelPlan"] = travel_plan
+
+        if isinstance(journey_log, (list, dict)) and journey_log:
+            vehicle_data["journeyLog"] = journey_log
 
         return vehicle.vin, vehicle_data
 

--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -34,6 +34,28 @@ from .utils import get_api_version
 _LOGGER = logging.getLogger(__name__)
 
 
+def _latest_journey_trip(data: dict) -> dict:
+    """Return the most recent journey-log trip, chosen by startTime.
+
+    The API has been observed to return trips newest-first, but the ordering
+    is not guaranteed — so we pick the trip with the highest startTime
+    explicitly rather than trusting index 0.
+    """
+    trips = data.get("journeyLog", {}).get("data") or []
+    if not trips:
+        return {}
+    return max(trips, key=lambda t: t.get("startTime") or 0)
+
+
+def _journey_last_duration(data: dict) -> int | None:
+    """Duration of the most recent trip, in whole minutes."""
+    trip = _latest_journey_trip(data)
+    start, end = trip.get("startTime"), trip.get("endTime")
+    if start and end:
+        return round((end - start) / 60000)
+    return None
+
+
 def get_tire_position_label(api_position: str, drive_side: str) -> str:
     """
     Map API tire position to display label based on vehicle drive side.
@@ -358,6 +380,8 @@ async def async_setup_entry(
         entities.append(ZeekrEngineStatusSensor(coordinator, vin))
 
         # Journey Log sensors
+        # Each "last" sensor reads the most recent trip via _latest_journey_trip
+        # (max startTime), so they stay correct regardless of API ordering.
         # Journey Log Last Distance
         entities.append(
             ZeekrSensor(
@@ -365,10 +389,10 @@ async def async_setup_entry(
                 vin,
                 "journey_log_last_distance",
                 "Journey Log Last Distance",
-                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("traveledDistance") if d.get("journeyLog", {}).get("data") else None,
+                lambda d: _latest_journey_trip(d).get("traveledDistance"),
                 UnitOfLength.KILOMETERS,
                 SensorDeviceClass.DISTANCE,
-                None,
+                SensorStateClass.MEASUREMENT,
             )
         )
         # Journey Log Last Avg Speed
@@ -378,23 +402,24 @@ async def async_setup_entry(
                 vin,
                 "journey_log_last_avg_speed",
                 "Journey Log Last Avg Speed",
-                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("avgSpeed") if d.get("journeyLog", {}).get("data") else None,
+                lambda d: _latest_journey_trip(d).get("avgSpeed"),
                 UnitOfSpeed.KILOMETERS_PER_HOUR,
                 SensorDeviceClass.SPEED,
-                None,
+                SensorStateClass.MEASUREMENT,
             )
         )
-        # Journey Log Last Consumption
+        # Journey Log Last Consumption (a rate in kWh/100km — no HA device_class
+        # exists for consumption-per-distance, so leave it unset).
         entities.append(
             ZeekrSensor(
                 coordinator,
                 vin,
                 "journey_log_last_consumption",
                 "Journey Log Last Consumption",
-                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("electricConsumption") if d.get("journeyLog", {}).get("data") else None,
+                lambda d: _latest_journey_trip(d).get("electricConsumption"),
                 "kWh/100km",
                 None,
-                None,
+                SensorStateClass.MEASUREMENT,
             )
         )
         # Journey Log Last Regeneration
@@ -404,10 +429,14 @@ async def async_setup_entry(
                 vin,
                 "journey_log_last_regeneration",
                 "Journey Log Last Regeneration",
-                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("electricRegeneration") if d.get("journeyLog", {}).get("data") else None,
+                lambda d: _latest_journey_trip(d).get("electricRegeneration"),
                 "Wh",
                 SensorDeviceClass.ENERGY,
-                None,
+                # Absolute Wh recovered per trip (e.g. 560 Wh on a 4 km trip) —
+                # read as a rate it would be an implausibly small ~5 Wh/100km, so
+                # this is energy, not a per-distance figure. MEASUREMENT records
+                # per-trip statistics.
+                SensorStateClass.MEASUREMENT,
             )
         )
         # Journey Log Last Duration
@@ -417,14 +446,10 @@ async def async_setup_entry(
                 vin,
                 "journey_log_last_duration",
                 "Journey Log Last Duration",
-                lambda d: (
-                    round((d.get("journeyLog", {}).get("data", [{}])[0].get("endTime", 0) - d.get("journeyLog", {}).get("data", [{}])[0].get("startTime", 0)) / 60000)
-                    if d.get("journeyLog", {}).get("data") and d.get("journeyLog", {}).get("data", [{}])[0].get("endTime") and d.get("journeyLog", {}).get("data", [{}])[0].get("startTime")
-                    else None
-                ),
+                _journey_last_duration,
                 UnitOfTime.MINUTES,
                 SensorDeviceClass.DURATION,
-                None,
+                SensorStateClass.MEASUREMENT,
             )
         )
         # Journey Log Total Trips (from API total)
@@ -736,10 +761,14 @@ class ZeekrEngineStatusSensor(CoordinatorEntity, SensorEntity):
 class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
     """Zeekr Journey Log sensor with trip history as attributes."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator: ZeekrCoordinator, vin: str):
         super().__init__(coordinator)
         self.vin = vin
-        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Journey Log"
+        # has_entity_name: the device name prefixes this automatically, matching
+        # every other sensor in the integration ("<device> Journey Log").
+        self._attr_name = "Journey Log"
         self._attr_unique_id = f"{vin}_journey_log"
         self._attr_icon = "mdi:map-marker-path"
 
@@ -761,6 +790,11 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
         if not trips_raw:
             return {}
 
+        # Newest trip first, regardless of API ordering.
+        trips_raw = sorted(
+            trips_raw, key=lambda t: t.get("startTime") or 0, reverse=True
+        )
+
         trips = []
         for trip in trips_raw:
             track_points = trip.get("trackPoints", [])
@@ -781,7 +815,9 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
                 "duration_min": duration_min,
                 "distance_km": trip.get("traveledDistance"),
                 "avg_speed_kmh": trip.get("avgSpeed"),
-                "consumption_kwh": trip.get("electricConsumption"),
+                # electricConsumption is a rate (kWh/100km), not absolute kWh —
+                # e.g. 21 on a 4 km trip. Key renamed to reflect the real unit.
+                "consumption_kwh_per_100km": trip.get("electricConsumption"),
                 "regeneration_wh": trip.get("electricRegeneration"),
                 "start_lat": start_point.get("latitude"),
                 "start_lon": start_point.get("longitude"),

--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfSpeed,
     UnitOfTemperature,
+    UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -356,6 +357,92 @@ async def async_setup_entry(
         entities.append(ZeekrVehicleStatusSensor(coordinator, vin))
         entities.append(ZeekrEngineStatusSensor(coordinator, vin))
 
+        # Journey Log sensors
+        # Journey Log Last Distance
+        entities.append(
+            ZeekrSensor(
+                coordinator,
+                vin,
+                "journey_log_last_distance",
+                "Journey Log Last Distance",
+                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("traveledDistance") if d.get("journeyLog", {}).get("data") else None,
+                UnitOfLength.KILOMETERS,
+                SensorDeviceClass.DISTANCE,
+                None,
+            )
+        )
+        # Journey Log Last Avg Speed
+        entities.append(
+            ZeekrSensor(
+                coordinator,
+                vin,
+                "journey_log_last_avg_speed",
+                "Journey Log Last Avg Speed",
+                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("avgSpeed") if d.get("journeyLog", {}).get("data") else None,
+                UnitOfSpeed.KILOMETERS_PER_HOUR,
+                SensorDeviceClass.SPEED,
+                None,
+            )
+        )
+        # Journey Log Last Consumption
+        entities.append(
+            ZeekrSensor(
+                coordinator,
+                vin,
+                "journey_log_last_consumption",
+                "Journey Log Last Consumption",
+                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("electricConsumption") if d.get("journeyLog", {}).get("data") else None,
+                "kWh/100km",
+                None,
+                None,
+            )
+        )
+        # Journey Log Last Regeneration
+        entities.append(
+            ZeekrSensor(
+                coordinator,
+                vin,
+                "journey_log_last_regeneration",
+                "Journey Log Last Regeneration",
+                lambda d: d.get("journeyLog", {}).get("data", [{}])[0].get("electricRegeneration") if d.get("journeyLog", {}).get("data") else None,
+                "Wh",
+                SensorDeviceClass.ENERGY,
+                None,
+            )
+        )
+        # Journey Log Last Duration
+        entities.append(
+            ZeekrSensor(
+                coordinator,
+                vin,
+                "journey_log_last_duration",
+                "Journey Log Last Duration",
+                lambda d: (
+                    round((d.get("journeyLog", {}).get("data", [{}])[0].get("endTime", 0) - d.get("journeyLog", {}).get("data", [{}])[0].get("startTime", 0)) / 60000)
+                    if d.get("journeyLog", {}).get("data") and d.get("journeyLog", {}).get("data", [{}])[0].get("endTime") and d.get("journeyLog", {}).get("data", [{}])[0].get("startTime")
+                    else None
+                ),
+                UnitOfTime.MINUTES,
+                SensorDeviceClass.DURATION,
+                None,
+            )
+        )
+        # Journey Log Total Trips (from API total)
+        entities.append(
+            ZeekrSensor(
+                coordinator,
+                vin,
+                "journey_log_total_trips",
+                "Journey Log Total Trips",
+                lambda d: d.get("journeyLog", {}).get("total"),
+                None,
+                None,
+                SensorStateClass.TOTAL,
+            )
+        )
+        # Journey Log sensor with trip history as attributes
+        entities.append(ZeekrJourneyLogSensor(coordinator, vin))
+
     async_add_entities(entities)
 
 
@@ -639,6 +726,80 @@ class ZeekrEngineStatusSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self.vin)},
+            "name": f"Zeekr {self.vin}",
+            "manufacturer": "Zeekr",
+        }
+
+
+class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
+    """Zeekr Journey Log sensor with trip history as attributes."""
+
+    def __init__(self, coordinator: ZeekrCoordinator, vin: str):
+        super().__init__(coordinator)
+        self.vin = vin
+        self._attr_name = f"Zeekr {vin[-4:] if vin else ''} Journey Log"
+        self._attr_unique_id = f"{vin}_journey_log"
+        self._attr_icon = "mdi:map-marker-path"
+
+    @property
+    def native_value(self):
+        """Return number of loaded trips."""
+        data = self.coordinator.data.get(self.vin, {})
+        journey_log = data.get("journeyLog", {})
+        trips = journey_log.get("data", [])
+        return len(trips)
+
+    @property
+    def extra_state_attributes(self):
+        """Return all trips as attributes."""
+        data = self.coordinator.data.get(self.vin, {})
+        journey_log = data.get("journeyLog", {})
+        trips_raw = journey_log.get("data", [])
+
+        if not trips_raw:
+            return {}
+
+        trips = []
+        for trip in trips_raw:
+            track_points = trip.get("trackPoints", [])
+            start_point = track_points[0] if track_points else {}
+            end_point = track_points[-1] if track_points else {}
+
+            # Calculate duration in minutes
+            start_ts = trip.get("startTime", 0)
+            end_ts = trip.get("endTime", 0)
+            duration_min = round((end_ts - start_ts) / 60000) if end_ts and start_ts else None
+
+            trips.append({
+                "trip_id": trip.get("tripId"),
+                "report_time": trip.get("reportTime"),
+                "vin": self.vin,
+                "start_time": start_ts,
+                "end_time": end_ts,
+                "duration_min": duration_min,
+                "distance_km": trip.get("traveledDistance"),
+                "avg_speed_kmh": trip.get("avgSpeed"),
+                "consumption_kwh": trip.get("electricConsumption"),
+                "regeneration_wh": trip.get("electricRegeneration"),
+                "start_lat": start_point.get("latitude"),
+                "start_lon": start_point.get("longitude"),
+                "end_lat": end_point.get("latitude"),
+                "end_lon": end_point.get("longitude"),
+                "start_odometer": trip.get("startOdometer"),
+                "end_odometer": trip.get("endOdometer"),
+            })
+
+        return {
+            "vin": self.vin,
+            "trips": trips,
+            "total_trips": journey_log.get("total", 0),
+        }
+
+    @property
+    def device_info(self):
+        """Return device info."""
         return {
             "identifiers": {(DOMAIN, self.vin)},
             "name": f"Zeekr {self.vin}",

--- a/custom_components/zeekr_ev/services.yaml
+++ b/custom_components/zeekr_ev/services.yaml
@@ -1,0 +1,29 @@
+get_trip_trackpoints:
+  name: Get Trip Trackpoints
+  description: Fetch detailed GPS trackpoints for a specific trip from the journey log.
+  fields:
+    vin:
+      name: VIN
+      description: Vehicle Identification Number
+      required: true
+      example: "LXXXA1SXXXN022XXX"
+      selector:
+        text:
+    trip_id:
+      name: Trip ID
+      description: The trip ID from the journey log
+      required: true
+      example: 3
+      selector:
+        number:
+          min: 0
+          mode: box
+    trip_report_time:
+      name: Trip Report Time
+      description: The reportTime timestamp from the trip (milliseconds since epoch)
+      required: true
+      example: 1769492206000
+      selector:
+        number:
+          min: 0
+          mode: box

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,6 +4,8 @@ from custom_components.zeekr_ev.sensor import (
     ZeekrVehicleStatusSensor,
     ZeekrEngineStatusSensor,
     ZeekrChargingTimeFormattedSensor,
+    _latest_journey_trip,
+    _journey_last_duration,
 )
 
 
@@ -364,3 +366,49 @@ def test_api_status_sensor_disconnected():
     coordinator = MockCoordinator()
     sensor = ZeekrAPIStatusSensor(coordinator, "entry_1")
     assert sensor.native_value == "Disconnected"
+
+
+# --- Journey Log helpers -------------------------------------------------
+
+def _journey_data(trips, total=50):
+    return {"journeyLog": {"total": total, "data": trips}}
+
+
+# Deliberately out of order (older trip first) — index 0 would be the wrong
+# trip here, which is exactly what the startTime lookup guards against.
+_JOURNEY_TRIPS = [
+    {
+        "tripId": 11,
+        "startTime": 1781695402000,
+        "endTime": 1781695928000,
+        "traveledDistance": 7,
+    },
+    {
+        "tripId": 12,
+        "startTime": 1781696400000,
+        "endTime": 1781696775000,
+        "traveledDistance": 4,
+    },
+]
+
+
+def test_latest_journey_trip_picks_newest_by_starttime():
+    """The newest trip wins on startTime, not on list position."""
+    latest = _latest_journey_trip(_journey_data(_JOURNEY_TRIPS))
+    assert latest["tripId"] == 12
+    assert latest["traveledDistance"] == 4
+
+
+def test_latest_journey_trip_handles_empty_inputs():
+    assert _latest_journey_trip({}) == {}
+    assert _latest_journey_trip(_journey_data([])) == {}
+
+
+def test_journey_last_duration_from_newest_trip():
+    # (1781696775000 - 1781696400000) / 60000 = 6.25 -> 6 minutes
+    assert _journey_last_duration(_journey_data(_JOURNEY_TRIPS)) == 6
+
+
+def test_journey_last_duration_missing_times_returns_none():
+    assert _journey_last_duration(_journey_data([{"startTime": 1}])) is None
+    assert _journey_last_duration({}) is None


### PR DESCRIPTION
Rebases @R3ffoTz's Journey log (#55) onto current `main`.

The original branch conflicted with two `main`-side refactors; resolved as follows:
- **`coordinator.py`** — `_async_update_vehicle` now fetches per-vehicle data via parallel `asyncio.gather` helpers, so the journey-log fetch is re-expressed as a `fetch_journey_log()` helper there (guarded by `hasattr(vehicle, "get_journey_log")`).
- **`sensor.py`** — a stale `ZeekrChargerStateSensor` (already replaced on `main`) was dropped; the journey-log sensors and the `get_trip_trackpoints` service are intact.

No functional changes beyond the rebase. All original commits and authorship by @R3ffoTz are preserved.

Local checks green: flake8, mypy, check-yaml, and the full pytest suite (84 passed, 61.79% coverage).

Supersedes #55.
