### PR TITLE
Don't expose API tokens as state attributes

### DIFF
--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -439,15 +439,10 @@ class ZeekrAPIStatusSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self):
-        """Return the state attributes including tokens only."""
+        """Return non-sensitive API status attributes (tokens redacted)."""
         attrs = {}
         client = self.coordinator.client
         if client:
-            attrs["auth_token"] = client.auth_token
-            attrs["bearer_token"] = client.bearer_token
-            attrs["access_token"] = (
-                client.bearer_token
-            )  # Same as bearer_token, for clarity
             attrs["logged_in"] = client.logged_in
             attrs["username"] = getattr(client, "username", None)
             attrs["region_code"] = getattr(client, "region_code", None)


### PR DESCRIPTION
Removes `auth_token`, `bearer_token`, and `access_token` from `ZeekrAPIStatusSensor.extra_state_attributes`.

HA state attributes are persisted to the recorder database and shown in the UI, Logbook, screenshots, and shared diagnostics — so the account's live API tokens were casually viewable and trivially leaked. The non-sensitive attributes (`logged_in`, `username`, `region_code`, hosts, `vehicle_count`, `x_vins`) are kept. If token visibility is ever needed for debugging, config-entry diagnostics with `async_redact_data` is the appropriate channel for sensitive values.

Fixes #112.
