### PR TITLE
Carry forward last-known vehicle data when a status poll fails

### DIFF
--- a/custom_components/zeekr_ev/coordinator.py
+++ b/custom_components/zeekr_ev/coordinator.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# How many consecutive failed status polls we serve last-known ("stale") data
+# for before we give up and let the vehicle drop out (return None). With the
+# default 5-minute polling interval this is ~15 minutes of carry-forward, after
+# which the entities go unavailable so a sustained outage stays visible.
+MAX_STALE_UPDATES = 3
+
 
 class ZeekrCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Zeekr data."""
@@ -46,6 +52,9 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         self.steering_wheel_duration = 15
         self.request_stats = ZeekrRequestStats(hass)
         self.latest_poll_time: Optional[str] = None  # Track latest poll time
+        # Count of consecutive failed status polls per VIN, so carry-forward of
+        # stale data is bounded (see MAX_STALE_UPDATES).
+        self._stale_count: dict[str, int] = {}
         polling_interval = entry.data.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL)
         super().__init__(
             hass,
@@ -87,8 +96,42 @@ class ZeekrCoordinator(DataUpdateCoordinator):
                 vehicle.get_status
             )
         except Exception as charge_err:
-            _LOGGER.error("Error fetching status for %s: %s", vehicle.vin, charge_err)
+            # Carry forward the last-known data instead of dropping the vehicle.
+            # A failed primary-status fetch (cloud briefly unreachable, or the
+            # car asleep) would otherwise flip every entity to "unknown" until
+            # the next successful poll. This is bounded: after MAX_STALE_UPDATES
+            # consecutive failures we stop holding values and return None, so a
+            # sustained outage still surfaces (entities go unavailable) rather
+            # than the integration silently serving stale data forever.
+            last_known = (self.data or {}).get(vehicle.vin)
+            stale_count = self._stale_count.get(vehicle.vin, 0) + 1
+            if last_known is not None and stale_count <= MAX_STALE_UPDATES:
+                self._stale_count[vehicle.vin] = stale_count
+                _LOGGER.warning(
+                    "Status fetch failed for %s (%s); serving last-known (stale) "
+                    "data [%d/%d]",
+                    vehicle.vin,
+                    charge_err,
+                    stale_count,
+                    MAX_STALE_UPDATES,
+                )
+                return vehicle.vin, last_known
+            if last_known is not None:
+                _LOGGER.error(
+                    "Status fetch failed for %s (%s); giving up after %d stale "
+                    "updates, vehicle will go unavailable",
+                    vehicle.vin,
+                    charge_err,
+                    MAX_STALE_UPDATES,
+                )
+            else:
+                _LOGGER.error(
+                    "Error fetching status for %s: %s", vehicle.vin, charge_err
+                )
             return None
+
+        # Primary status fetch succeeded — clear any stale streak for this VIN.
+        self._stale_count.pop(vehicle.vin, None)
 
         # Define parallel tasks
         async def fetch_remote_control_state():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -45,6 +45,7 @@ def mock_data_update_coordinator_init(self, hass, logger, name, update_interval=
     self.logger = logger
     self.name = name
     self.update_interval = update_interval
+    self.data = None  # matches DataUpdateCoordinator, which initialises data to None
     self._listeners = []
     self._micro_controller = MagicMock()
 
@@ -236,6 +237,133 @@ async def test_coordinator_update_charging_limit_failure():
         # Others should be present because they run in parallel and return_exceptions=True
         assert "chargingStatus" in data[vin]
         assert "remoteControlState" in data[vin]["additionalVehicleStatus"]
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_carries_forward_last_known_on_status_failure():
+    """A failed primary-status fetch keeps the last-known data for that VIN."""
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    vehicle.get_status.side_effect = Exception("API Error")
+
+    client = MockClient([vehicle])
+    hass = DummyHass()
+
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__", side_effect=mock_data_update_coordinator_init, autospec=True):
+        coordinator = ZeekrCoordinator(hass, client, DummyConfig())
+
+    coordinator.request_stats = MagicMock()
+    coordinator.request_stats.async_inc_request = AsyncMock()
+
+    # Seed last-known data from a previous successful poll.
+    previous = {vin: {"additionalVehicleStatus": {"foo": "bar"}}}
+    coordinator.data = previous
+
+    try:
+        result = await coordinator._async_update_vehicle(vehicle)
+        assert result == (vin, previous[vin])
+        # Sub-fetches must not run when the primary status fetch fails.
+        vehicle.get_remote_control_state.assert_not_called()
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_returns_none_when_no_last_known():
+    """With no prior data, a failed status fetch still returns None (genuine unknown)."""
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    vehicle.get_status.side_effect = Exception("API Error")
+
+    client = MockClient([vehicle])
+    hass = DummyHass()
+
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__", side_effect=mock_data_update_coordinator_init, autospec=True):
+        coordinator = ZeekrCoordinator(hass, client, DummyConfig())
+
+    coordinator.request_stats = MagicMock()
+    coordinator.request_stats.async_inc_request = AsyncMock()
+    coordinator.data = None
+
+    try:
+        result = await coordinator._async_update_vehicle(vehicle)
+        assert result is None
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_stops_carrying_forward_after_max_stale_updates():
+    """Carry-forward is bounded: after MAX_STALE_UPDATES failures it returns None."""
+    from custom_components.zeekr_ev.coordinator import MAX_STALE_UPDATES
+
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    vehicle.get_status.side_effect = Exception("API Error")
+
+    client = MockClient([vehicle])
+    hass = DummyHass()
+
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__", side_effect=mock_data_update_coordinator_init, autospec=True):
+        coordinator = ZeekrCoordinator(hass, client, DummyConfig())
+
+    coordinator.request_stats = MagicMock()
+    coordinator.request_stats.async_inc_request = AsyncMock()
+
+    previous = {vin: {"additionalVehicleStatus": {"foo": "bar"}}}
+    coordinator.data = previous
+
+    try:
+        # The first MAX_STALE_UPDATES failures carry the last-known data forward.
+        for _ in range(MAX_STALE_UPDATES):
+            assert await coordinator._async_update_vehicle(vehicle) == (vin, previous[vin])
+        # The next failure exceeds the budget and drops the vehicle.
+        assert await coordinator._async_update_vehicle(vehicle) is None
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_coordinator_resets_stale_count_on_successful_poll():
+    """A successful poll clears the stale streak so carry-forward starts fresh."""
+    from custom_components.zeekr_ev.coordinator import MAX_STALE_UPDATES
+
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    good_status = {"additionalVehicleStatus": {"foo": "bar"}}
+
+    client = MockClient([vehicle])
+    hass = DummyHass()
+
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__", side_effect=mock_data_update_coordinator_init, autospec=True):
+        coordinator = ZeekrCoordinator(hass, client, DummyConfig())
+
+    coordinator.request_stats = MagicMock()
+    coordinator.request_stats.async_inc_request = AsyncMock()
+    coordinator.data = {vin: good_status}
+
+    try:
+        # Burn through the stale budget with failures.
+        vehicle.get_status.side_effect = Exception("API Error")
+        for _ in range(MAX_STALE_UPDATES):
+            await coordinator._async_update_vehicle(vehicle)
+        assert coordinator._stale_count.get(vin) == MAX_STALE_UPDATES
+
+        # A successful poll resets the streak...
+        vehicle.get_status.side_effect = None
+        vehicle.get_status.return_value = good_status
+        await coordinator._async_update_vehicle(vehicle)
+        assert vin not in coordinator._stale_count
+
+        # ...so carry-forward is available again for a fresh failure.
+        vehicle.get_status.side_effect = Exception("API Error")
+        assert await coordinator._async_update_vehicle(vehicle) == (vin, good_status)
     finally:
         if coordinator._unsub_reset:
             coordinator._unsub_reset()


### PR DESCRIPTION
Hi again! 🙏 Following up on the reliability pass — this one's in the coordinator rather than the library.

When the primary `get_status` fetch for a vehicle fails (cloud briefly unreachable, or the car asleep so the gateway has nothing fresh), `_async_update_vehicle` returns `None`, which drops that VIN from the coordinator data — so every entity for the car flips to `unknown` until the next successful poll. The parallel sub-fetches already degrade gracefully; it's just the primary fetch that takes everything down.

This carries the last-known data forward instead (standard `cloud_polling` behaviour). If there's no prior data (genuine first-run failure) it still returns `None`.

- small change in `_async_update_vehicle` + 2 tests
- also set `self.data = None` in the test helper's mock init to mirror the real `DataUpdateCoordinator`

**One open design question** (worth your call): this trades the brief "unknown" flicker for showing the last-known values, which does make a transient outage *less visible*. If you'd rather the integration signal staleness — e.g. a data-age attribute, or flipping availability after N consecutive failures — instead of silently holding values, I'm very happy to go that route. What's your preference?

Thanks!
