### PR TITLE
Reconcile charging limit after a write instead of waiting for the next poll

### DIFF
--- a/custom_components/zeekr_ev/number.py
+++ b/custom_components/zeekr_ev/number.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from homeassistant.components.number import NumberEntity, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTime
@@ -168,5 +170,19 @@ class ZeekrChargingLimitNumber(ZeekrEntity, RestoreNumber):
         await self.hass.async_add_executor_job(
             vehicle.do_remote_control, command, service_id, setting
         )
+
+        # Reflect the new target immediately (native_value prefers the
+        # coordinator value, which would otherwise snap back to the old SoC),
+        # then reconcile from the backend after a short delay — an immediate
+        # poll can still return the previous SoC before the car applies it.
+        self.coordinator.data.setdefault(self.vin, {}).setdefault("chargingLimit", {})[
+            "soc"
+        ] = soc_value
         self._attr_native_value = value
         self.async_write_ha_state()
+
+        async def _reconcile() -> None:
+            await asyncio.sleep(10)
+            await self.coordinator.async_request_refresh()
+
+        self.hass.async_create_task(_reconcile())

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,6 +1,14 @@
-from unittest.mock import MagicMock, AsyncMock
+import asyncio
+from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
 from custom_components.zeekr_ev.number import ZeekrChargingLimitNumber, ZeekrConfigNumber
+
+
+@pytest.fixture(autouse=True)
+def _instant_sleep():
+    """Make the post-write reconcile delay instant in tests."""
+    with patch("custom_components.zeekr_ev.number.asyncio.sleep", new=AsyncMock()):
+        yield
 
 
 class MockVehicle:
@@ -36,9 +44,15 @@ class DummyHass:
     def __init__(self):
         self.config = DummyConfig()
         self.data = {}
+        self.created_tasks = []
 
     async def async_add_executor_job(self, func, *args, **kwargs):
         return func(*args, **kwargs)
+
+    def async_create_task(self, coro, *args, **kwargs):
+        task = asyncio.ensure_future(coro)
+        self.created_tasks.append(task)
+        return task
 
 
 @pytest.mark.asyncio
@@ -79,6 +93,32 @@ async def test_charging_limit_number():
     # Check optimistic update
     assert number_entity.native_value == 80.0
     number_entity.async_write_ha_state.assert_called()
+
+    # Drain the scheduled reconcile task to avoid a dangling pending task.
+    await asyncio.gather(*number_entity.hass.created_tasks)
+
+
+@pytest.mark.asyncio
+async def test_charging_limit_write_reconciles_after_delay():
+    """A charging-limit write updates the value immediately and schedules a refresh."""
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    coordinator = MockCoordinator([vehicle])
+
+    number_entity = ZeekrChargingLimitNumber(coordinator, vin)
+    number_entity.hass = DummyHass()
+    number_entity.async_write_ha_state = MagicMock()
+
+    await number_entity.async_set_native_value(80.0)
+
+    # Optimistic coordinator update so native_value doesn't snap back.
+    assert coordinator.data[vin]["chargingLimit"]["soc"] == 800
+    assert number_entity.native_value == 80.0
+
+    # A reconcile task was scheduled; run it and confirm it refreshes.
+    assert number_entity.hass.created_tasks
+    await asyncio.gather(*number_entity.hass.created_tasks)
+    coordinator.async_request_refresh.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi again! 🙏 One more small coordinator/UI fix.

Setting the charging limit (`number.charging_limit`) sends the new SoC, but nothing reconciles it afterwards — `native_value` prefers the coordinator's value, so the UI snaps back to the old target until the next 5-min poll.

This reflects the new target immediately (optimistic coordinator update, like the switch entities do) and schedules a short delayed `async_request_refresh()`. Delayed rather than immediate avoids reading the previous SoC before the car has applied it — same reasoning as the sentry-mode delayed refresh already in `switch.py`.

- small change in `ZeekrChargingLimitNumber.async_set_native_value` + 1 test
- 89/89 green

Sibling to #119. Thanks!
