### PR TITLE
Confirm charging stop before writing state (symmetric with start) — fixes #117

### DIFF
--- a/custom_components/zeekr_ev/switch.py
+++ b/custom_components/zeekr_ev/switch.py
@@ -300,15 +300,46 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
             await self.hass.async_add_executor_job(
                 vehicle.do_remote_control, command, service_id, setting
             )
-            self._update_local_state_optimistically(is_on=False)
-            self.async_write_ha_state()
-            if self.field == "sentry_mode":
+            if self.field == "charging":
+                # Wait for backend confirmation that charging has stopped — symmetric
+                # with async_turn_on. An immediate coordinator refresh can still read the
+                # previous (charging) state and revert the switch off->on (~115-142 ms);
+                # see Fryyyyy/zeekr_homeassistant#117.
+                timeout = 30  # seconds
+                poll_interval = 2
+                waited = 0
+                stop_confirmed = False
+                while waited < timeout:
+                    try:
+                        status = await self.hass.async_add_executor_job(vehicle.get_charging_status)
+                        await asyncio.sleep(poll_interval)
+                        waited += poll_interval
+                        charger_state = (
+                            status.get("chargerState")
+                            if isinstance(status, dict) else None
+                        )
+                        # iOS trace: chargerState 25/26 is stopped, 1/2 is charging
+                        if charger_state is not None and str(charger_state) in ("25", "26"):
+                            stop_confirmed = True
+                            break
+                    except Exception as e:
+                        _LOGGER.info("Error while polling for charging stop confirmation: %s", e)
+                        pass
+                # Confirmed stopped -> off; if never confirmed, stay on (still charging)
+                self._update_local_state_optimistically(is_on=not stop_confirmed)
+                self.async_write_ha_state()
+            elif self.field == "sentry_mode":
+                self._update_local_state_optimistically(is_on=False)
+                self.async_write_ha_state()
+
                 async def delayed_refresh():
                     await asyncio.sleep(10)
                     await self.coordinator.async_request_refresh()
 
                 self.hass.async_create_task(delayed_refresh())
             else:
+                self._update_local_state_optimistically(is_on=False)
+                self.async_write_ha_state()
                 await self.coordinator.async_request_refresh()
 
     def _update_local_state_optimistically(self, is_on: bool) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -181,8 +181,10 @@ async def test_charging_switch():
         "electricVehicleStatus"]["chargerState"] == "2"
     switch.async_write_ha_state.assert_called()
 
-    # Test Turn Off (Stop Charging)
-    await switch.async_turn_off()
+    # Test Turn Off (Stop Charging) — confirm-loop polls until stopped (25/26)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        vehicle_mock.get_charging_status = MagicMock(return_value={"chargerState": "25"})
+        await switch.async_turn_off()
 
     vehicle_mock.do_remote_control.assert_called_with(
         "stop",
@@ -196,10 +198,20 @@ async def test_charging_switch():
             ]
         }
     )
-    # Optimistic update
+    # Confirmed stopped -> optimistic off
     assert coordinator.data[vin]["additionalVehicleStatus"][
         "electricVehicleStatus"]["chargerState"] == "25"
     switch.async_write_ha_state.assert_called()
+
+    # Test Turn Off timeout — backend keeps reporting charging (2): stay ON, no revert.
+    # This is the #117 fix: an unconfirmed stop must NOT optimistically flip off.
+    coordinator.data[vin]["additionalVehicleStatus"][
+        "electricVehicleStatus"]["chargerState"] = "2"
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        vehicle_mock.get_charging_status = MagicMock(return_value={"chargerState": "2"})
+        await switch.async_turn_off()
+    assert coordinator.data[vin]["additionalVehicleStatus"][
+        "electricVehicleStatus"]["chargerState"] == "2"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi @Fryyyyy — thanks for this integration, it's been a genuine pleasure to build on.

## The problem (#117)

The charge **start** path (`ZeekrSwitch.async_turn_on`, `field == "charging"`) already waits for the backend to confirm before trusting the state: it polls `chargerState` every 2s for up to 30s and only marks the switch on once the car actually reports charging (`1`/`2`).

The **stop** path doesn't. After `rcs.terminate` it does an immediate `coordinator.async_request_refresh()` — and because the backend lags the command by ~115–142 ms, that refresh often still reads the *previous* (charging) state, so the switch reverts `off → on` a moment after you turn it off. The two paths are asymmetric, and stop is the one that bites.

## The fix

Make stop symmetric with start: after `rcs.terminate`, poll `chargerState` until it reports stopped (`25`/`26`) or the 30s timeout elapses, then write state **once** — instead of the immediate, stale-prone refresh.

- Confirmed stopped → switch **off**.
- Not confirmed within the timeout → **leave it on** (the car is presumably still charging — better than optimistically claiming off and being wrong).

It reuses the same loop shape, timeout (30s) and poll interval (2s) as the existing start confirmation, so it reads as a mirror of code you already have. Only the `charging` stop path changes — `sentry_mode` (delayed refresh) and the other fields (immediate refresh) are untouched, so behaviour elsewhere is identical.

## Tests

Extends `test_charging_switch` with two cases:
- a stop that **confirms** (`chargerState → 25` → switch off), and
- a stop that **times out** (backend keeps reporting charging → switch stays on, no revert).

## Open to feedback

Very happy to adjust the shape — e.g. factor the timeout/interval out and share it with the start loop, or source the stopped-state codes (`25`/`26`) from a constant alongside the charging codes. Whatever fits your taste for the codebase.
