### PR TITLE
Refresh on car-confirmed charge start/stop instead of optimistic write (follow-up to #122 review)

### DIFF
--- a/custom_components/zeekr_ev/switch.py
+++ b/custom_components/zeekr_ev/switch.py
@@ -220,10 +220,13 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
                         _LOGGER.info("Error while polling for charging status confirmation: %s", e)
                         pass
                 if charging_confirmed:
-                    self._update_local_state_optimistically(is_on=True)
+                    # Car-confirmed charging — the loop waited for the backend, so refresh
+                    # the real state directly instead of an optimistic write (PR #122 review).
+                    await self.coordinator.async_request_refresh()
                 else:
+                    # Not confirmed within the timeout — start didn't take; optimistic off.
                     self._update_local_state_optimistically(is_on=False)
-                self.async_write_ha_state()
+                    self.async_write_ha_state()
             elif self.field == "sentry_mode":
                 self._update_local_state_optimistically(is_on=True)
                 self.async_write_ha_state()
@@ -325,9 +328,16 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
                     except Exception as e:
                         _LOGGER.info("Error while polling for charging stop confirmation: %s", e)
                         pass
-                # Confirmed stopped -> off; if never confirmed, stay on (still charging)
-                self._update_local_state_optimistically(is_on=not stop_confirmed)
-                self.async_write_ha_state()
+                if stop_confirmed:
+                    # Car-confirmed stop — the loop waited for the backend, so refresh the
+                    # real state directly (no off->on revert risk) instead of an optimistic
+                    # write that isn't actually optimistic anymore (PR #122 review).
+                    await self.coordinator.async_request_refresh()
+                else:
+                    # Stop not confirmed within the timeout — keep it on (still charging);
+                    # don't trust a possibly-stale refresh here.
+                    self._update_local_state_optimistically(is_on=True)
+                    self.async_write_ha_state()
             elif self.field == "sentry_mode":
                 self._update_local_state_optimistically(is_on=False)
                 self.async_write_ha_state()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -18,15 +18,13 @@ class MockCoordinator:
         self.data = data
         self.vehicles = {}
         self.async_inc_invoke = AsyncMock()
+        self.async_request_refresh = AsyncMock()
         self.steering_wheel_duration = 15
 
     def get_vehicle_by_vin(self, vin):
         return self.vehicles.get(vin)
 
     def inc_invoke(self):
-        pass
-
-    async def async_request_refresh(self):
         pass
 
 
@@ -176,10 +174,9 @@ async def test_charging_switch():
             ]
         }
     )
-    # Optimistic update
-    assert coordinator.data[vin]["additionalVehicleStatus"][
-        "electricVehicleStatus"]["chargerState"] == "2"
-    switch.async_write_ha_state.assert_called()
+    # Car-confirmed charging -> coordinator refresh (not an optimistic local write)
+    coordinator.async_request_refresh.assert_awaited()
+    coordinator.async_request_refresh.reset_mock()
 
     # Test Turn Off (Stop Charging) — confirm-loop polls until stopped (25/26)
     with patch("asyncio.sleep", new_callable=AsyncMock):
@@ -198,13 +195,12 @@ async def test_charging_switch():
             ]
         }
     )
-    # Confirmed stopped -> optimistic off
-    assert coordinator.data[vin]["additionalVehicleStatus"][
-        "electricVehicleStatus"]["chargerState"] == "25"
-    switch.async_write_ha_state.assert_called()
+    # Car-confirmed stop -> coordinator refresh (not an optimistic local write)
+    coordinator.async_request_refresh.assert_awaited()
+    coordinator.async_request_refresh.reset_mock()
 
     # Test Turn Off timeout — backend keeps reporting charging (2): stay ON, no revert.
-    # This is the #117 fix: an unconfirmed stop must NOT optimistically flip off.
+    # Unconfirmed stop keeps the optimistic "on" and does NOT refresh (stale-risk).
     coordinator.data[vin]["additionalVehicleStatus"][
         "electricVehicleStatus"]["chargerState"] = "2"
     with patch("asyncio.sleep", new_callable=AsyncMock):
@@ -212,6 +208,7 @@ async def test_charging_switch():
         await switch.async_turn_off()
     assert coordinator.data[vin]["additionalVehicleStatus"][
         "electricVehicleStatus"]["chargerState"] == "2"
+    coordinator.async_request_refresh.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to your nit on #122 🙏 — you're right, after the confirm-loop the state is confirmed by the car, so calling `_update_local_state_optimistically` there was a misnomer.

This refreshes from the coordinator directly on the **confirmed** branch — the loop has already waited for the backend to settle, so there's no stale-read / off→on revert risk. The optimistic write stays only for the **timeout** fallback: there it genuinely is optimistic, and a direct refresh could read a stale state (the original #117 trap). Applied symmetrically to start (`async_turn_on`) and stop (`async_turn_off`) so the two paths match.

Tests assert the coordinator refresh on the confirmed start/stop and no refresh on the timeout path (8/8 switch tests green).

Happy to trim it down if you'd rather keep it to the stop path only.
