### PR TITLE
fix(journey-log): keep Journey Log sensor attributes under HA's 16KB cap

### DIFF
--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 
 from homeassistant.components.sensor import (
@@ -32,6 +33,13 @@ from .coordinator import ZeekrCoordinator
 from .utils import get_api_version
 
 _LOGGER = logging.getLogger(__name__)
+
+# Home Assistant refuses to store state attributes larger than 16384 bytes
+# ("Attributes will not be stored" + a DB-performance warning). A full
+# journey-log page (up to 50 trips) can exceed that, so the Journey Log sensor
+# includes only the most-recent trips that fit within this safe budget (headroom
+# left for the wrapper keys + HA's own serialization overhead).
+_JOURNEY_LOG_ATTR_BUDGET = 14000
 
 
 def _latest_journey_trip(data: dict) -> dict:
@@ -777,7 +785,15 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self):
-        """Return all trips as attributes."""
+        """Return recent trips as attributes.
+
+        HA caps stored state attributes at 16384 bytes; a full 50-trip page can
+        exceed that ("Attributes will not be stored" + DB-performance warning).
+        So we include the most-recent trips that fit within
+        ``_JOURNEY_LOG_ATTR_BUDGET`` and expose ``displayed_trips`` vs.
+        ``total_trips`` so the cap is transparent. The dedicated ``last_*``
+        sensors carry the latest trip for long-term statistics regardless.
+        """
         data = self.coordinator.data.get(self.vin, {})
         journey_log = data.get("journeyLog", {})
         trips_raw = journey_log.get("data", [])
@@ -791,6 +807,7 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
         )
 
         trips = []
+        used = 0
         for trip in trips_raw:
             track_points = trip.get("trackPoints", [])
             start_point = track_points[0] if track_points else {}
@@ -801,10 +818,13 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
             end_ts = trip.get("endTime", 0)
             duration_min = round((end_ts - start_ts) / 60000) if end_ts and start_ts else None
 
-            trips.append({
+            entry = {
+                # trip_id + report_time are the handle for the
+                # zeekr_ev.get_trip_trackpoints service (full GPS route on
+                # demand); the top-level "vin" key already identifies the car,
+                # so it isn't repeated per trip.
                 "trip_id": trip.get("tripId"),
                 "report_time": trip.get("reportTime"),
-                "vin": self.vin,
                 "start_time": start_ts,
                 "end_time": end_ts,
                 "duration_min": duration_min,
@@ -820,11 +840,19 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
                 "end_lon": end_point.get("longitude"),
                 "start_odometer": trip.get("startOdometer"),
                 "end_odometer": trip.get("endOdometer"),
-            })
+            }
+
+            # Stop before the blob would exceed HA's attribute cap, but always
+            # keep at least the most-recent trip.
+            used += len(json.dumps(entry, default=str))
+            if trips and used > _JOURNEY_LOG_ATTR_BUDGET:
+                break
+            trips.append(entry)
 
         return {
             "vin": self.vin,
             "trips": trips,
+            "displayed_trips": len(trips),
             "total_trips": journey_log.get("total", 0),
         }
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,9 +4,11 @@ from custom_components.zeekr_ev.sensor import (
     ZeekrVehicleStatusSensor,
     ZeekrEngineStatusSensor,
     ZeekrChargingTimeFormattedSensor,
+    ZeekrJourneyLogSensor,
     _latest_journey_trip,
     _journey_last_duration,
 )
+import json
 
 
 class DummyCoordinator:
@@ -412,3 +414,64 @@ def test_journey_last_duration_from_newest_trip():
 def test_journey_last_duration_missing_times_returns_none():
     assert _journey_last_duration(_journey_data([{"startTime": 1}])) is None
     assert _journey_last_duration({}) is None
+
+
+# --- Journey Log attribute size cap --------------------------------------
+
+def _make_trips(n):
+    """n realistic full trips (with start/end GPS markers + odometers)."""
+    base = 1781600000000
+    trips = []
+    for i in range(n):
+        start = base + i * 3_600_000
+        trips.append({
+            "tripId": 1000 + i,
+            "reportTime": start,
+            "startTime": start,
+            "endTime": start + 1_800_000,
+            "traveledDistance": 42.7,
+            "avgSpeed": 53.2,
+            "electricConsumption": 18.4,
+            "electricRegeneration": 560,
+            "startOdometer": 12345.6 + i,
+            "endOdometer": 12388.3 + i,
+            "trackPoints": [
+                {"latitude": 52.0907374, "longitude": 5.1214201},
+                {"latitude": 52.3675734, "longitude": 4.9041389},
+            ],
+        })
+    return trips
+
+
+def test_journey_log_attributes_stay_under_ha_16kb_cap():
+    """A full 50-trip page must not exceed HA's 16384-byte attribute limit."""
+    coordinator = DummyCoordinator({"VIN1": _journey_data(_make_trips(50), total=50)})
+    sensor = ZeekrJourneyLogSensor(coordinator, "VIN1")
+    attrs = sensor.extra_state_attributes
+
+    assert len(json.dumps(attrs, default=str)) <= 16384
+    # The page is capped, but the full count is still reported.
+    assert attrs["total_trips"] == 50
+    assert attrs["displayed_trips"] == len(attrs["trips"])
+    assert attrs["displayed_trips"] < 50
+    # Newest trip is kept (sorted newest-first by start_time).
+    assert attrs["trips"][0]["trip_id"] == 1049
+    # Redundant per-trip vin is dropped; GPS markers are retained.
+    assert "vin" not in attrs["trips"][0]
+    assert attrs["trips"][0]["start_lat"] == 52.0907374
+
+
+def test_journey_log_attributes_small_page_keeps_all_trips():
+    """A handful of trips fits comfortably and is not capped."""
+    coordinator = DummyCoordinator({"VIN1": _journey_data(_make_trips(3), total=3)})
+    sensor = ZeekrJourneyLogSensor(coordinator, "VIN1")
+    attrs = sensor.extra_state_attributes
+
+    assert attrs["displayed_trips"] == 3
+    assert len(json.dumps(attrs, default=str)) <= 16384
+
+
+def test_journey_log_attributes_empty_when_no_trips():
+    coordinator = DummyCoordinator({"VIN1": _journey_data([], total=0)})
+    sensor = ZeekrJourneyLogSensor(coordinator, "VIN1")
+    assert sensor.extra_state_attributes == {}


### PR DESCRIPTION
Fixes #126.

This is our journey-log code (#111, rebased from @R3ffoTz's #55), so we're owning the fix. 🙂

## Problem
`ZeekrJourneyLogSensor` packed the full journey-log page (up to ~50 trips) into one `trips` attribute. On accounts with real trip data that exceeds HA's 16384-byte attribute cap → *"Attributes will not be stored"* + a DB-performance warning.

## Approach
Two complementary changes — be **selective** about what's stored, then **bound** it hard:

1. **Drop the redundant per-trip `vin`** — the top-level `vin` key already identifies the car; repeating it ~50× was pure waste.
2. **Byte-budget cap** (`_JOURNEY_LOG_ATTR_BUDGET = 14000`): include the most-recent trips that fit under the budget, always keeping at least the latest trip. Leaves headroom for the wrapper keys + HA's own serialization overhead.
3. **Transparency**: expose `displayed_trips` alongside `total_trips`, so a capped page is obvious rather than silently truncated.

**Kept deliberately:** the start/end GPS markers (handy for a map tile) and the odometers. The *full* per-trip route was never in the attributes anyway — it's fetched on demand via the existing `zeekr_ev.get_trip_trackpoints` service (which needs `trip_id` + `report_time`, both retained per trip).

## Result
A full 50-trip page now serializes well under 16384 bytes; ~36 most-recent trips are shown with full markers, guaranteed under the cap regardless of trip size variance. The dedicated `last_*` sensors still carry the latest trip for long-term statistics.

## Tests
Added to `tests/test_sensor.py`:
- a 50-trip page stays ≤ 16384 bytes, is capped (`displayed_trips < 50`), reports `total_trips == 50`, keeps the newest trip first, drops per-trip `vin`, retains GPS markers;
- a small page (3 trips) is not capped;
- empty input is safe.

`pytest tests/test_sensor.py` → 26 passed; `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
