### PR TITLE
Fix TypeError when journeyLog data is null

### DIFF
--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -780,7 +780,12 @@ class ZeekrJourneyLogSensor(CoordinatorEntity, SensorEntity):
         """Return number of loaded trips."""
         data = self.coordinator.data.get(self.vin, {})
         journey_log = data.get("journeyLog", {})
-        trips = journey_log.get("data", [])
+        # The API sometimes returns {"data": null} (e.g. zero trips on record)
+        # instead of omitting the key or returning []. dict.get(key, default)
+        # only applies the default when the key is *absent*, so an explicit
+        # null still comes back as None here and len(None) raises TypeError.
+        # Match the same "or []" guard already used by _latest_journey_trip().
+        trips = journey_log.get("data") or []
         return len(trips)
 
     @property

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -475,3 +475,18 @@ def test_journey_log_attributes_empty_when_no_trips():
     coordinator = DummyCoordinator({"VIN1": _journey_data([], total=0)})
     sensor = ZeekrJourneyLogSensor(coordinator, "VIN1")
     assert sensor.extra_state_attributes == {}
+
+
+def test_journey_log_native_value_zero_when_data_key_missing():
+    coordinator = DummyCoordinator({"VIN1": _journey_data([], total=0)})
+    sensor = ZeekrJourneyLogSensor(coordinator, "VIN1")
+    assert sensor.native_value == 0
+
+
+def test_journey_log_native_value_zero_when_data_is_null():
+    """Regression test: API can return {"data": null} instead of {"data": []}
+    (observed on accounts/vehicles with zero recorded trips). native_value
+    must not raise TypeError('object of type NoneType has no len()')."""
+    coordinator = DummyCoordinator({"VIN1": {"journeyLog": {"total": 0, "data": None}}})
+    sensor = ZeekrJourneyLogSensor(coordinator, "VIN1")
+    assert sensor.native_value == 0


### PR DESCRIPTION

## Summary

`ZeekrJourneyLogSensor.native_value` crashes with `TypeError: object of type 'NoneType' has no len()` when the Zeekr API returns `"journeyLog": {"data": null}` instead of an empty list. On affected vehicles/accounts this fires on **every** coordinator update (~every 5 minutes), flooding the log and leaving `sensor.<car>_journey_log` unavailable.

## Root cause

```python
trips = journey_log.get("data", [])
return len(trips)
```

`dict.get(key, default)` only substitutes the default when the key is **absent**. The API sends the `data` key present but explicitly `null`, so `.get("data", [])` returns `None`, and `len(None)` raises.

The rest of the module already guards against this — `_latest_journey_trip()` uses `.get("data") or []`, and `extra_state_attributes` has an early `if not trips_raw: return {}`. Only `native_value` was missing the guard.

## Fix

Use the same `or []` pattern already established elsewhere in the file:

```python
trips = journey_log.get("data") or []
return len(trips)
```

## Reproduction

Coordinator data with `journeyLog.data == None` (observed on a vehicle with no recorded trips):

```
TypeError: object of type 'NoneType' has no len()
  File ".../custom_components/zeekr_ev/sensor.py", line 776, in native_value
    return len(trips)
```

## Tests

Added two regression tests to `tests/test_sensor.py`:

- `test_journey_log_native_value_zero_when_data_key_missing` — `data == []`
- `test_journey_log_native_value_zero_when_data_is_null` — `data == None` (this fails on `main`, passes with the fix)

All existing journey-log / sensor tests continue to pass.

## Notes

- One-line behavioural change plus tests; no public API or entity-schema changes.
- Follows the existing coding style (`black`) and the `or []` idiom already used in this file.