### PR TITLE
fix(journey-log): drop invalid energy device_class on Last Regeneration sensor

### DIFF
--- a/custom_components/zeekr_ev/sensor.py
+++ b/custom_components/zeekr_ev/sensor.py
@@ -430,7 +430,13 @@ async def async_setup_entry(
                 SensorStateClass.MEASUREMENT,
             )
         )
-        # Journey Log Last Regeneration
+        # Journey Log Last Regeneration (absolute Wh recovered on the last trip —
+        # e.g. 560 Wh on a 4 km trip; read as a rate it would be an implausibly
+        # small ~5 Wh/100km, so this is energy, not a per-distance figure). It is
+        # a per-trip snapshot, not a cumulative meter, so HA rejects the `energy`
+        # device_class with state_class `measurement`. Leave the device_class
+        # unset (like Last Consumption above) and keep MEASUREMENT for per-trip
+        # statistics.
         entities.append(
             ZeekrSensor(
                 coordinator,
@@ -439,11 +445,7 @@ async def async_setup_entry(
                 "Journey Log Last Regeneration",
                 lambda d: _latest_journey_trip(d).get("electricRegeneration"),
                 "Wh",
-                SensorDeviceClass.ENERGY,
-                # Absolute Wh recovered per trip (e.g. 560 Wh on a 4 km trip) —
-                # read as a rate it would be an implausibly small ~5 Wh/100km, so
-                # this is energy, not a per-distance figure. MEASUREMENT records
-                # per-trip statistics.
+                None,
                 SensorStateClass.MEASUREMENT,
             )
         )


### PR DESCRIPTION
Fixes #135

The Journey Log Last Regeneration sensor sets device_class `energy` with
state_class `measurement`, which HA rejects — an `energy` device_class only
allows `total`, `total_increasing` or None. Hence the log warning:

  Entity sensor...journey_log_last_regeneration is using state class
  'measurement' which is impossible considering device class ('energy')

Last Regeneration is a per-trip snapshot (Wh recovered on the last trip), not
a cumulative meter, so it doesn't really belong on an energy device_class or
the energy dashboard anyway. This drops the device_class (leaving it unset,
same as the sibling Last Consumption sensor) and keeps MEASUREMENT so per-trip
statistics are still recorded.

Came in with the journey-log sensors (#111); only surfacing now that the
HA / py3.14 loop + validation checks are stricter.
