### PR TITLE
fix(coordinator): carry secondary fetches forward on an empty poll

### DIFF
--- a/custom_components/zeekr_ev/coordinator.py
+++ b/custom_components/zeekr_ev/coordinator.py
@@ -33,6 +33,16 @@ _LOGGER = logging.getLogger(__name__)
 MAX_STALE_UPDATES = 3
 
 
+def _payload(value, types) -> object | None:
+    """Normalise an asyncio.gather() result to its payload, or None.
+
+    gather(return_exceptions=True) hands back either the fetch's return value or
+    the exception it raised, and a fetch that failed softly returns None or an
+    empty container. All of those mean "no data this poll".
+    """
+    return value if isinstance(value, types) and value else None
+
+
 class ZeekrCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Zeekr data."""
 
@@ -55,6 +65,12 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         # Count of consecutive failed status polls per VIN, so carry-forward of
         # stale data is bounded (see MAX_STALE_UPDATES).
         self._stale_count: dict[str, int] = {}
+        # Last successful payload of each secondary fetch, per VIN, plus the
+        # matching consecutive-failure counters. Kept as the raw per-endpoint
+        # response rather than a slice of the merged vehicle_data, so carrying a
+        # value forward can never clobber fresh primary-status fields.
+        self._last_secondary: dict[str, dict[str, object]] = {}
+        self._secondary_stale_count: dict[tuple[str, str], int] = {}
         polling_interval = entry.data.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL)
         super().__init__(
             hass,
@@ -209,28 +225,93 @@ class ZeekrCoordinator(DataUpdateCoordinator):
 
         remote_state, charging_status, charging_limit, charge_plan, travel_plan, journey_log = results
 
-        # Process results
-        if isinstance(remote_state, dict) and remote_state:
+        # Process results. Each secondary fetch is best-effort, so a single bad
+        # response would otherwise leave its key out of this poll's data and
+        # flip every entity reading it to unknown (or 0) until the next good
+        # poll. The journey log endpoint does this every few minutes on a parked
+        # car, making its six sensors flap constantly. Hold the last-known value
+        # instead, bounded per endpoint by the same MAX_STALE_UPDATES budget the
+        # primary status fetch uses so a dead endpoint still surfaces.
+        remote_state = self._fresh_or_last_known(
+            vehicle.vin, "remoteControlState", _payload(remote_state, dict)
+        )
+        charging_status = self._fresh_or_last_known(
+            vehicle.vin, "chargingStatus", _payload(charging_status, dict)
+        )
+        charging_limit = self._fresh_or_last_known(
+            vehicle.vin, "chargingLimit", _payload(charging_limit, dict)
+        )
+        charge_plan = self._fresh_or_last_known(
+            vehicle.vin, "chargePlan", _payload(charge_plan, dict)
+        )
+        travel_plan = self._fresh_or_last_known(
+            vehicle.vin, "travelPlan", _payload(travel_plan, dict)
+        )
+        journey_log = self._fresh_or_last_known(
+            vehicle.vin, "journeyLog", _payload(journey_log, (list, dict))
+        )
+
+        if remote_state:
             vehicle_data.setdefault("additionalVehicleStatus", {})[
                 "remoteControlState"
             ] = remote_state
 
-        if isinstance(charging_status, dict) and charging_status:
+        if charging_status:
             vehicle_data.setdefault("chargingStatus", {}).update(charging_status)
 
-        if isinstance(charging_limit, dict) and charging_limit:
+        if charging_limit:
             vehicle_data["chargingLimit"] = charging_limit
 
-        if isinstance(charge_plan, dict) and charge_plan:
+        if charge_plan:
             vehicle_data["chargePlan"] = charge_plan
 
-        if isinstance(travel_plan, dict) and travel_plan:
+        if travel_plan:
             vehicle_data["travelPlan"] = travel_plan
 
-        if isinstance(journey_log, (list, dict)) and journey_log:
+        if journey_log:
             vehicle_data["journeyLog"] = journey_log
 
         return vehicle.vin, vehicle_data
+
+    def _fresh_or_last_known(self, vin: str, name: str, value: object | None):
+        """Return this poll's payload, or the last-known one if it came up empty.
+
+        Carry-forward is bounded per (VIN, endpoint): after MAX_STALE_UPDATES
+        consecutive empty polls we stop holding the value, so an endpoint that
+        genuinely went away still drops out instead of being served forever.
+        """
+        key = (vin, name)
+        if value is not None:
+            self._last_secondary.setdefault(vin, {})[name] = value
+            self._secondary_stale_count.pop(key, None)
+            return value
+
+        previous = self._last_secondary.get(vin, {}).get(name)
+        if previous is None:
+            return None
+
+        stale_count = self._secondary_stale_count.get(key, 0) + 1
+        if stale_count > MAX_STALE_UPDATES:
+            _LOGGER.warning(
+                "%s fetch for %s has returned no data for %d consecutive polls; "
+                "dropping it rather than serving stale data",
+                name,
+                vin,
+                stale_count - 1,
+            )
+            self._last_secondary.get(vin, {}).pop(name, None)
+            self._secondary_stale_count.pop(key, None)
+            return None
+
+        self._secondary_stale_count[key] = stale_count
+        _LOGGER.debug(
+            "%s fetch for %s returned no data; serving last-known value [%d/%d]",
+            name,
+            vin,
+            stale_count,
+            MAX_STALE_UPDATES,
+        )
+        return previous
 
     async def _async_update_data(self) -> dict[str, dict]:
         """Fetch data from API endpoint."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -367,3 +367,147 @@ async def test_coordinator_resets_stale_count_on_successful_poll():
     finally:
         if coordinator._unsub_reset:
             coordinator._unsub_reset()
+
+
+def _coordinator_with_vehicle(vehicle):
+    """Build a coordinator wired to a single mock vehicle, stats stubbed out."""
+    client = MockClient([vehicle])
+    hass = DummyHass()
+
+    with patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__", side_effect=mock_data_update_coordinator_init, autospec=True):
+        coordinator = ZeekrCoordinator(hass, client, DummyConfig())
+
+    coordinator.request_stats = MagicMock()
+    coordinator.request_stats.async_load = AsyncMock()
+    coordinator.request_stats.async_inc_request = AsyncMock()
+    return coordinator
+
+
+def _vehicle_with_journey_log(vin="VIN1"):
+    """A mock vehicle whose secondary fetches all succeed, journey log included.
+
+    get_status uses a side_effect so every poll gets a *fresh* dict, the way the
+    real client does. A shared return_value dict would be mutated in place by
+    the coordinator and leak the previous poll's keys into the next one.
+    """
+    vehicle = MockVehicle(vin)
+    vehicle.get_status.side_effect = lambda: {}
+    vehicle.get_remote_control_state.return_value = {"remote": "ok"}
+    vehicle.get_charging_status.return_value = {"status": "ok"}
+    vehicle.get_charging_limit.return_value = {"soc": "800"}
+    vehicle.get_charge_plan.return_value = {"startTime": "00:00"}
+    vehicle.get_travel_plan.return_value = {"scheduledTime": "1700000000000"}
+    vehicle.get_journey_log = MagicMock(return_value=[{"tripId": "1"}])
+    return vehicle
+
+
+@pytest.mark.asyncio
+async def test_secondary_fetch_carries_forward_on_empty_poll():
+    """An empty journey-log poll keeps the previous value instead of dropping it."""
+    vin = "VIN1"
+    vehicle = _vehicle_with_journey_log(vin)
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, first = await coordinator._async_update_vehicle(vehicle)
+        assert first["journeyLog"] == [{"tripId": "1"}]
+
+        # The endpoint intermittently answers with an empty list.
+        vehicle.get_journey_log.return_value = []
+        _, second = await coordinator._async_update_vehicle(vehicle)
+        assert second["journeyLog"] == [{"tripId": "1"}]
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_secondary_fetch_carry_forward_is_bounded():
+    """After MAX_STALE_UPDATES empty polls the key drops rather than going stale forever."""
+    from custom_components.zeekr_ev.coordinator import MAX_STALE_UPDATES
+
+    vin = "VIN1"
+    vehicle = _vehicle_with_journey_log(vin)
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        await coordinator._async_update_vehicle(vehicle)
+
+        vehicle.get_journey_log.return_value = []
+        for _ in range(MAX_STALE_UPDATES):
+            _, data = await coordinator._async_update_vehicle(vehicle)
+            assert data["journeyLog"] == [{"tripId": "1"}]
+
+        _, data = await coordinator._async_update_vehicle(vehicle)
+        assert "journeyLog" not in data
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_secondary_fetch_stale_streak_resets_on_success():
+    """A good poll resets the streak, so an alternating endpoint never expires."""
+    from custom_components.zeekr_ev.coordinator import MAX_STALE_UPDATES
+
+    vin = "VIN1"
+    vehicle = _vehicle_with_journey_log(vin)
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        await coordinator._async_update_vehicle(vehicle)
+
+        # This is the observed real-world pattern: fail, recover, fail, recover.
+        for _ in range(MAX_STALE_UPDATES * 3):
+            vehicle.get_journey_log.return_value = []
+            _, data = await coordinator._async_update_vehicle(vehicle)
+            assert data["journeyLog"] == [{"tripId": "1"}]
+
+            vehicle.get_journey_log.return_value = [{"tripId": "1"}]
+            _, data = await coordinator._async_update_vehicle(vehicle)
+            assert data["journeyLog"] == [{"tripId": "1"}]
+            assert (vin, "journeyLog") not in coordinator._secondary_stale_count
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_carry_forward_does_not_clobber_fresh_primary_status():
+    """Carried-forward chargingStatus must not overwrite fresh primary-status fields."""
+    vin = "VIN1"
+    vehicle = _vehicle_with_journey_log(vin)
+    vehicle.get_status.side_effect = lambda: {"chargingStatus": {"soc": "50"}}
+    vehicle.get_charging_status.return_value = {"plugState": "1"}
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, first = await coordinator._async_update_vehicle(vehicle)
+        assert first["chargingStatus"] == {"soc": "50", "plugState": "1"}
+
+        # Primary status moves on while the secondary fetch comes back empty.
+        vehicle.get_status.side_effect = lambda: {"chargingStatus": {"soc": "72"}}
+        vehicle.get_charging_status.return_value = {}
+        _, second = await coordinator._async_update_vehicle(vehicle)
+
+        # The fresh SoC survives; only the secondary fetch's own field is held.
+        assert second["chargingStatus"] == {"soc": "72", "plugState": "1"}
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_no_carry_forward_without_a_previous_value():
+    """An endpoint that has never answered stays absent — nothing to carry."""
+    vin = "VIN1"
+    vehicle = _vehicle_with_journey_log(vin)
+    vehicle.get_journey_log.return_value = []
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, data = await coordinator._async_update_vehicle(vehicle)
+        assert "journeyLog" not in data
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()


### PR DESCRIPTION
Fixes #144.

The primary status fetch already carries the last-known data forward when a poll fails, bounded by `MAX_STALE_UPDATES`. The six secondary fetches never got that, so a single empty response drops the key from that poll's `vehicle_data` and every entity reading it falls to unknown (or 0) until the next good poll.

Journey log trips this every 5–15 minutes on my parked car — all six journey-log sensors flap in lockstep, 25 state changes in 6 hours on a car that hasn't moved.

This gives the secondary fetches the same bounded carry-forward, per (VIN, endpoint). An endpoint that genuinely goes away still drops out after `MAX_STALE_UPDATES` empty polls instead of being served stale forever.

One design note worth flagging: the last-known payloads are cached per endpoint (`_last_secondary`) rather than sliced back out of the merged `vehicle_data`. `chargingStatus` gets `.update()`-ed over whatever the primary status returned, so carrying the *merged* dict forward would let a stale value overwrite a fresh SoC. There's a test for exactly that case.

I also bumped the give-up path to `warning`. The per-poll failures stay at `debug`, but an endpoint that has gone quiet for several polls now says so — chasing this down was harder than it needed to be because nothing appeared in the log at default level.

**Tests:** 5 new, 4 of which fail on `main` and pass here (the fifth is a guard that an endpoint which has never answered stays absent). Full suite: 103 passed.
