### PR TITLE
Add refrigeration box support

### DIFF
--- a/custom_components/zeekr_ev/climate.py
+++ b/custom_components/zeekr_ev/climate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from math import isfinite
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -14,11 +15,24 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    VTM_COOL_DEFAULT_TEMP,
+    VTM_COOL_MAX_TEMP,
+    VTM_COOL_MIN_TEMP,
+    VTM_HEAT_DEFAULT_TEMP,
+    VTM_HEAT_MAX_TEMP,
+    VTM_HEAT_MIN_TEMP,
+)
 from .coordinator import ZeekrCoordinator
+from .entity import (
+    setup_refrigeration_box_discovery,
+    ZeekrRefrigerationBoxEntity,
+)
 
 
 async def async_setup_entry(
@@ -28,10 +42,16 @@ async def async_setup_entry(
 ) -> None:
     """Set up the climate platform."""
     coordinator: ZeekrCoordinator = hass.data[DOMAIN][entry.entry_id]
-    entities: list[ZeekrClimate] = []
-
-    for vin in coordinator.data:
-        entities.append(ZeekrClimate(coordinator, vin))
+    entities: list[ClimateEntity] = [
+        ZeekrClimate(coordinator, vin) for vin in coordinator.data
+    ]
+    setup_refrigeration_box_discovery(
+        coordinator,
+        entry,
+        async_add_entities,
+        entities,
+        ZeekrRefrigerationBoxClimate,
+    )
 
     async_add_entities(entities)
 
@@ -198,3 +218,122 @@ class ZeekrClimate(CoordinatorEntity, ClimateEntity):
             "name": f"Zeekr {self.vin}",
             "manufacturer": "Zeekr",
         }
+
+
+class ZeekrRefrigerationBoxClimate(
+    ZeekrRefrigerationBoxEntity,
+    ClimateEntity,
+):
+    """Control a fitted Zeekr refrigeration box."""
+
+    _attr_name = "Refrigeration Box"
+    _attr_icon = "mdi:fridge-outline"
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_target_temperature_step = 1
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT]
+
+    def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
+        """Initialise the refrigeration-box climate entity."""
+        super().__init__(coordinator, vin)
+        self._attr_unique_id = f"{vin}_refrigeration_box"
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the measured box temperature."""
+        try:
+            status, _ = self._vtm_state()
+            value = status.get("currentTemperature") if status else None
+            temperature = float(value) if value is not None else None
+            return (
+                temperature
+                if temperature is not None and isfinite(temperature)
+                else None
+            )
+        except (AttributeError, TypeError, ValueError):
+            return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the configured box temperature."""
+        _, setting = self._vtm_state()
+        return float(setting["temp"]) if setting else None
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return off, cooling, or heating from the implicit target range."""
+        status, setting = self._vtm_state()
+        if status is None or setting is None or status.get("activeStatus") != "1":
+            return HVACMode.OFF
+        return (
+            HVACMode.HEAT
+            if float(setting["temp"]) >= VTM_HEAT_MIN_TEMP
+            else HVACMode.COOL
+        )
+
+    def _temperature_range(self) -> tuple[float, float]:
+        """Return target bounds for the current implicit mode."""
+        _, setting = self._vtm_state()
+        heating = (
+            setting is not None
+            and float(setting["temp"]) >= VTM_HEAT_MIN_TEMP
+        )
+        return (
+            (VTM_HEAT_MIN_TEMP, VTM_HEAT_MAX_TEMP)
+            if heating
+            else (VTM_COOL_MIN_TEMP, VTM_COOL_MAX_TEMP)
+        )
+
+    @property
+    def min_temp(self) -> float:
+        """Return the lower bound for the target's implicit mode."""
+        return self._temperature_range()[0]
+
+    @property
+    def max_temp(self) -> float:
+        """Return the upper bound for the target's implicit mode."""
+        return self._temperature_range()[1]
+
+    async def async_turn_on(self) -> None:
+        """Turn on with the cached target and timer."""
+        await self._async_write_vtm(active=True)
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set refrigeration-box power and implicit operating mode."""
+        if hvac_mode == HVACMode.OFF:
+            await self._async_write_vtm(active=False)
+            return
+
+        if hvac_mode == HVACMode.COOL:
+            temp_mode = (
+                VTM_COOL_MIN_TEMP,
+                VTM_COOL_MAX_TEMP,
+                VTM_COOL_DEFAULT_TEMP,
+            )
+        elif hvac_mode == HVACMode.HEAT:
+            temp_mode = (
+                VTM_HEAT_MIN_TEMP,
+                VTM_HEAT_MAX_TEMP,
+                VTM_HEAT_DEFAULT_TEMP,
+            )
+        else:
+            return
+        await self._async_write_vtm(temp_mode=temp_mode, active=True)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set the refrigeration-box target without changing power."""
+        if (temperature := kwargs.get("temperature")) is not None:
+            temperature = float(temperature)
+            minimum, maximum = self._temperature_range()
+            if (
+                not isfinite(temperature)
+                or not minimum <= temperature <= maximum
+            ):
+                raise HomeAssistantError(
+                    f"Temperature must be between {minimum} and {maximum} °C"
+                )
+            await self._async_write_vtm(temp=temperature)

--- a/custom_components/zeekr_ev/const.py
+++ b/custom_components/zeekr_ev/const.py
@@ -70,6 +70,16 @@ DRIVE_SIDE_RHD = "rhd"
 DEFAULT_NAME = DOMAIN
 DEFAULT_POLLING_INTERVAL = 5  # minutes
 
+# Refrigeration-box protocol bounds
+VTM_COOL_MIN_TEMP = -15
+VTM_COOL_MAX_TEMP = 20
+VTM_COOL_DEFAULT_TEMP = 3
+VTM_HEAT_MIN_TEMP = 35
+VTM_HEAT_MAX_TEMP = 50
+VTM_HEAT_DEFAULT_TEMP = 50
+VTM_MIN_DURATION = 60
+VTM_MAX_DURATION = 1440
+
 # Country code to (country_name, region) mapping
 COUNTRY_CODE_MAPPING = {
     "AD": ("Andorra", "EU"),

--- a/custom_components/zeekr_ev/coordinator.py
+++ b/custom_components/zeekr_ev/coordinator.py
@@ -5,16 +5,29 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta, datetime
 import logging
+from math import isfinite
+from time import monotonic
 from typing import TYPE_CHECKING, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 import homeassistant.helpers.event as event
 
 
-from .const import CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL, DOMAIN
+from .const import (
+    CONF_POLLING_INTERVAL,
+    DEFAULT_POLLING_INTERVAL,
+    DOMAIN,
+    VTM_COOL_MAX_TEMP,
+    VTM_COOL_MIN_TEMP,
+    VTM_HEAT_MAX_TEMP,
+    VTM_HEAT_MIN_TEMP,
+    VTM_MAX_DURATION,
+    VTM_MIN_DURATION,
+)
 from .request_stats import ZeekrRequestStats
 
 if TYPE_CHECKING:
@@ -31,6 +44,8 @@ _LOGGER = logging.getLogger(__name__)
 # default 5-minute polling interval this is ~15 minutes of carry-forward, after
 # which the entities go unavailable so a sustained outage stays visible.
 MAX_STALE_UPDATES = 3
+VTM_SETTLE_SECONDS = 30
+VTM_STORAGE_VERSION = 1
 
 
 def _payload(value, types) -> object | None:
@@ -41,6 +56,125 @@ def _payload(value, types) -> object | None:
     empty container. All of those mean "no data this poll".
     """
     return value if isinstance(value, types) and value else None
+
+
+def get_vtm_setting(value: object) -> dict | None:
+    """Return a usable refrigeration-box setting, if present."""
+    if not isinstance(value, dict):
+        return None
+    if value.get("activeStatus") not in ("0", "1"):
+        return None
+    ts_active = value.get("vtmTsActive")
+    if (
+        not isinstance(ts_active, (str, bool))
+        or str(ts_active).lower() not in ("true", "false")
+    ):
+        return None
+    model = value.get("vtmModel")
+    if not isinstance(model, dict):
+        return None
+    settings = model.get("setting")
+    if not isinstance(settings, list) or not settings:
+        return None
+    setting = settings[0]
+    if not isinstance(setting, dict):
+        return None
+    try:
+        temp_value = setting["temp"]
+        duration_value = setting["duration"]
+        if isinstance(temp_value, bool) or isinstance(duration_value, bool):
+            return None
+        temp = float(temp_value)
+        duration = float(duration_value)
+        if not isfinite(temp) or not isfinite(duration):
+            return None
+        if not (
+            VTM_COOL_MIN_TEMP <= temp <= VTM_COOL_MAX_TEMP
+            or VTM_HEAT_MIN_TEMP <= temp <= VTM_HEAT_MAX_TEMP
+        ):
+            return None
+        if (
+            not duration.is_integer()
+            or not VTM_MIN_DURATION <= duration <= VTM_MAX_DURATION
+        ):
+            return None
+    except (KeyError, TypeError, ValueError):
+        return None
+    return setting
+
+
+def _cacheable_vtm_status(value: object) -> dict | None:
+    """Return only the controls needed to restart an off box."""
+    setting = get_vtm_setting(value)
+    if setting is None or not isinstance(value, dict):
+        return None
+    return {
+        "activeStatus": "0",
+        "vtmTsActive": value["vtmTsActive"],
+        "vtmModel": {
+            "setting": [
+                {
+                    "temp": setting["temp"],
+                    "duration": setting["duration"],
+                }
+            ]
+        },
+    }
+
+
+def _merge_vtm_off_status(value: object, cached: object) -> object:
+    """Fill a partial off response with the last usable controls."""
+    if (
+        get_vtm_setting(value) is not None
+        or not isinstance(value, dict)
+        or value.get("activeStatus") != "0"
+    ):
+        return value
+
+    setting = get_vtm_setting(cached)
+    if setting is None or not isinstance(cached, dict):
+        return value
+
+    status = value.copy()
+    status.setdefault("vtmTsActive", cached["vtmTsActive"])
+    if get_vtm_setting(status) is not None:
+        return status
+    model = status.get("vtmModel")
+    status["vtmModel"] = {
+        **(model if isinstance(model, dict) else {}),
+        "setting": [setting.copy()],
+    }
+    return status
+
+
+def _apply_vtm_pending(
+    pending_by_vin: dict[str, dict[str, tuple[str, float]]],
+    vin: str,
+    status: object,
+) -> dict | None:
+    """Overlay acknowledged fields until the backend confirms or times out."""
+    setting = get_vtm_setting(status)
+    pending = pending_by_vin.get(vin)
+    if setting is None or not pending:
+        return setting
+
+    assert isinstance(status, dict)
+    now = monotonic()
+    for field, (value, expires) in list(pending.items()):
+        target = status if field == "activeStatus" else setting
+        current = target[field]
+        confirmed = (
+            float(current) == float(value)
+            if field in ("temp", "duration")
+            else str(current) == value
+        )
+        if confirmed or now >= expires:
+            pending.pop(field)
+        else:
+            target[field] = value
+    if not pending:
+        pending_by_vin.pop(vin)
+    return setting
 
 
 class ZeekrCoordinator(DataUpdateCoordinator):
@@ -71,6 +205,19 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         # value forward can never clobber fresh primary-status fields.
         self._last_secondary: dict[str, dict[str, object]] = {}
         self._secondary_stale_count: dict[tuple[str, str], int] = {}
+        # Missing means probing, True means fitted, and False means three
+        # consecutive responses lacked usable refrigeration-box settings.
+        self._vtm_support: dict[str, bool] = {}
+        self._vtm_unusable_count: dict[str, int] = {}
+        self._vtm_store: Store[dict[str, dict]] = Store(
+            hass,
+            VTM_STORAGE_VERSION,
+            f"{DOMAIN}.{entry.entry_id}.vtm",
+        )
+        self._vtm_cache: dict[str, dict] = {}
+        self.vtm_locks: dict[str, asyncio.Lock] = {}
+        self._vtm_pending: dict[str, dict[str, tuple[str, float]]] = {}
+        self._vtm_reconcile_tasks: dict[str, asyncio.Task] = {}
         polling_interval = entry.data.get(CONF_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL)
         super().__init__(
             hass,
@@ -91,8 +238,17 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         )
 
     async def async_init_stats(self):
-        """Initialize stats (load from storage)."""
+        """Load persistent coordinator state."""
         await self.request_stats.async_load()
+        stored = await self._vtm_store.async_load()
+        if isinstance(stored, dict):
+            self._vtm_cache = {
+                vin: cached
+                for vin, value in stored.items()
+                if isinstance(vin, str)
+                and (cached := _cacheable_vtm_status(value)) is not None
+            }
+            self._vtm_support.update(dict.fromkeys(self._vtm_cache, True))
 
     async def _handle_daily_reset(self, now):
         await self.request_stats.async_reset_today()
@@ -103,6 +259,14 @@ class ZeekrCoordinator(DataUpdateCoordinator):
             if vehicle.vin == vin:
                 return vehicle
         return None
+
+    def _cache_vtm_status(self, vin: str, status: object) -> None:
+        """Remember controls across partial off responses and HA restarts."""
+        cached = _cacheable_vtm_status(status)
+        if cached is None or self._vtm_cache.get(vin) == cached:
+            return
+        self._vtm_cache[vin] = cached
+        self._vtm_store.async_delay_save(lambda: self._vtm_cache, 1)
 
     async def _async_update_vehicle(self, vehicle: Vehicle) -> tuple[str, dict] | None:
         """Fetch data for a single vehicle."""
@@ -212,6 +376,46 @@ class ZeekrCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Error fetching journey log for %s: %s", vehicle.vin, e)
                 return None
 
+        async def fetch_vtm_status():
+            if (
+                self._vtm_support.get(vehicle.vin) is False
+                or not hasattr(vehicle, "get_vtm_status")
+            ):
+                return None
+            try:
+                await self.request_stats.async_inc_request()
+                value = await self.hass.async_add_executor_job(
+                    vehicle.get_vtm_status
+                )
+            except Exception as e:
+                self._vtm_unusable_count.pop(vehicle.vin, None)
+                _LOGGER.debug("Error fetching VTM status for %s: %s", vehicle.vin, e)
+                return None
+
+            value = _merge_vtm_off_status(
+                value,
+                self._last_secondary.get(vehicle.vin, {}).get("vtmStatus")
+                or self._vtm_cache.get(vehicle.vin),
+            )
+            if _apply_vtm_pending(
+                self._vtm_pending, vehicle.vin, value
+            ) is not None:
+                self._vtm_support[vehicle.vin] = True
+                self._vtm_unusable_count.pop(vehicle.vin, None)
+                self._cache_vtm_status(vehicle.vin, value)
+                return value
+            if isinstance(value, dict) and value.get("activeStatus") == "0":
+                self._vtm_unusable_count.pop(vehicle.vin, None)
+                return None
+            if vehicle.vin not in self._vtm_support:
+                count = self._vtm_unusable_count.get(vehicle.vin, 0) + 1
+                if count >= MAX_STALE_UPDATES:
+                    self._vtm_support[vehicle.vin] = False
+                    self._vtm_unusable_count.pop(vehicle.vin, None)
+                else:
+                    self._vtm_unusable_count[vehicle.vin] = count
+            return None
+
         # Execute parallel tasks
         results = await asyncio.gather(
             fetch_remote_control_state(),
@@ -220,10 +424,19 @@ class ZeekrCoordinator(DataUpdateCoordinator):
             fetch_charge_plan(),
             fetch_travel_plan(),
             fetch_journey_log(),
+            fetch_vtm_status(),
             return_exceptions=True
         )
 
-        remote_state, charging_status, charging_limit, charge_plan, travel_plan, journey_log = results
+        (
+            remote_state,
+            charging_status,
+            charging_limit,
+            charge_plan,
+            travel_plan,
+            journey_log,
+            vtm_status,
+        ) = results
 
         # Process results. Each secondary fetch is best-effort, so a single bad
         # response would otherwise leave its key out of this poll's data and
@@ -250,6 +463,10 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         journey_log = self._fresh_or_last_known(
             vehicle.vin, "journeyLog", _payload(journey_log, (list, dict))
         )
+        if self._vtm_support.get(vehicle.vin):
+            vtm_status = self._fresh_or_last_known(
+                vehicle.vin, "vtmStatus", _payload(vtm_status, dict)
+            )
 
         if remote_state:
             vehicle_data.setdefault("additionalVehicleStatus", {})[
@@ -270,6 +487,9 @@ class ZeekrCoordinator(DataUpdateCoordinator):
 
         if journey_log:
             vehicle_data["journeyLog"] = journey_log
+
+        if vtm_status:
+            vehicle_data["vtmStatus"] = vtm_status
 
         return vehicle.vin, vehicle_data
 
@@ -315,6 +535,7 @@ class ZeekrCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[str, dict]:
         """Fetch data from API endpoint."""
+        acquired_vtm_locks: list[asyncio.Lock] = []
         try:
             # Refresh vehicle list if empty (first run)
             if not self.vehicles:
@@ -322,6 +543,12 @@ class ZeekrCoordinator(DataUpdateCoordinator):
                 self.vehicles = await self.hass.async_add_executor_job(
                     self.client.get_vehicle_list
                 )
+
+            # Keep writes out until the complete poll snapshot is ready to publish.
+            for vehicle in self.vehicles:
+                lock = self.vtm_locks.setdefault(vehicle.vin, asyncio.Lock())
+                await lock.acquire()
+                acquired_vtm_locks.append(lock)
 
             # Update all vehicles in parallel
             tasks = [self._async_update_vehicle(vehicle) for vehicle in self.vehicles]
@@ -342,7 +569,11 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         else:
+            self.data = data
             return data
+        finally:
+            for lock in reversed(acquired_vtm_locks):
+                lock.release()
 
     async def async_inc_invoke(self):
         await self.request_stats.async_inc_invoke()

--- a/custom_components/zeekr_ev/entity.py
+++ b/custom_components/zeekr_ev/entity.py
@@ -2,14 +2,53 @@
 
 from __future__ import annotations
 
+import asyncio
+from time import monotonic
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import ZeekrCoordinator
+from .coordinator import (
+    _apply_vtm_pending,
+    _merge_vtm_off_status,
+    get_vtm_setting,
+    VTM_SETTLE_SECONDS,
+    ZeekrCoordinator,
+)
 
 import logging
 _LOGGER = logging.getLogger(__name__)
+
+
+def setup_refrigeration_box_discovery(
+    coordinator,
+    entry,
+    async_add_entities,
+    entities,
+    entity_class,
+) -> None:
+    """Add fitted refrigeration-box entities now and after later discovery."""
+    known_vins: set[str] = set()
+
+    def discover():
+        discovered = [
+            entity_class(coordinator, vin)
+            for vin, vehicle_data in coordinator.data.items()
+            if vin not in known_vins
+            and get_vtm_setting(vehicle_data.get("vtmStatus")) is not None
+        ]
+        known_vins.update(entity.vin for entity in discovered)
+        return discovered
+
+    entities.extend(discover())
+
+    def add_discovered() -> None:
+        if discovered := discover():
+            async_add_entities(discovered)
+
+    entry.async_on_unload(coordinator.async_add_listener(add_discovered))
 
 
 class ZeekrEntity(CoordinatorEntity[ZeekrCoordinator]):
@@ -33,4 +72,149 @@ class ZeekrEntity(CoordinatorEntity[ZeekrCoordinator]):
                 name=vehicle.vin,
                 manufacturer="Zeekr",
                 model=f"{plate_no} (OS Version {display_os_version})" if display_os_version else plate_no or "Zeekr EV",
+            )
+
+
+class ZeekrRefrigerationBoxEntity(ZeekrEntity):
+    """Shared refrigeration-box state and command handling."""
+
+    def _vtm_state(self) -> tuple[dict | None, dict | None]:
+        """Return the current validated status and setting."""
+        status = self.coordinator.data.get(self.vin, {}).get("vtmStatus")
+        setting = get_vtm_setting(status)
+        return (status, setting) if setting is not None else (None, None)
+
+    @property
+    def available(self) -> bool:
+        """Return whether a usable refrigeration-box response is available."""
+        return super().available and self._vtm_state()[1] is not None
+
+    async def _async_write_vtm(
+        self,
+        *,
+        temp: float | None = None,
+        temp_mode: tuple[float, float, float] | None = None,
+        duration: int | None = None,
+        active: bool | None = None,
+    ) -> None:
+        """Merge one change into the latest VTM state and send it."""
+        lock = self.coordinator.vtm_locks.setdefault(self.vin, asyncio.Lock())
+        async with lock:
+            vehicle = self.coordinator.get_vehicle_by_vin(self.vin)
+            if vehicle is None:
+                raise HomeAssistantError("Refrigeration box is unavailable")
+
+            try:
+                await self.coordinator.request_stats.async_inc_request()
+                status = await self.hass.async_add_executor_job(
+                    vehicle.get_vtm_status
+                )
+            except Exception as err:
+                raise HomeAssistantError(
+                    "Refrigeration box is unavailable"
+                ) from err
+
+            status = _merge_vtm_off_status(
+                status,
+                self.coordinator.data.get(self.vin, {}).get("vtmStatus"),
+            )
+            setting = _apply_vtm_pending(
+                self.coordinator._vtm_pending,
+                self.vin,
+                status,
+            )
+            if setting is None or not isinstance(status, dict):
+                raise HomeAssistantError("Refrigeration box is unavailable")
+            if temp_mode is not None:
+                minimum, maximum, default = temp_mode
+                fresh_temp = float(setting["temp"])
+                temp = fresh_temp if minimum <= fresh_temp <= maximum else default
+
+            next_active = (
+                status.get("activeStatus") == "1"
+                if active is None
+                else active
+            )
+            next_ts = str(status.get("vtmTsActive", "false")).lower()
+            temp_value = (
+                str(setting["temp"]) if temp is None else str(float(temp))
+            )
+            duration_value = str(
+                int(float(setting["duration"]) if duration is None else duration)
+            )
+            command_setting = {
+                "serviceParameters": [
+                    {"key": "temp", "value": temp_value},
+                    {"key": "duration", "value": duration_value},
+                    {"key": "zaj.ts", "value": next_ts},
+                ]
+            }
+
+            await self.coordinator.async_inc_invoke()
+            try:
+                success = await self.hass.async_add_executor_job(
+                    vehicle.do_remote_control,
+                    "start" if next_active else "stop",
+                    "ZAJ",
+                    command_setting,
+                )
+            except Exception as err:
+                raise HomeAssistantError(
+                    "Refrigeration-box command failed"
+                ) from err
+            if not success:
+                raise HomeAssistantError("Refrigeration-box command failed")
+
+            changes = {}
+            if temp is not None:
+                changes["temp"] = temp_value
+            if duration is not None:
+                changes["duration"] = duration_value
+            if active is not None:
+                changes["activeStatus"] = "1" if next_active else "0"
+            deadline = monotonic() + VTM_SETTLE_SECONDS
+            pending = self.coordinator._vtm_pending.setdefault(self.vin, {})
+            for field, (value, _) in pending.items():
+                pending[field] = (value, deadline)
+            pending.update(
+                (field, (value, deadline)) for field, value in changes.items()
+            )
+            setting["temp"] = temp_value
+            setting["duration"] = duration_value
+            status["vtmTsActive"] = next_ts
+            status["activeStatus"] = "1" if next_active else "0"
+            self.coordinator._cache_vtm_status(self.vin, status)
+            self.coordinator.data.setdefault(self.vin, {})["vtmStatus"] = status
+            self.coordinator._last_secondary.setdefault(self.vin, {})[
+                "vtmStatus"
+            ] = status
+            self.coordinator._secondary_stale_count.pop(
+                (self.vin, "vtmStatus"), None
+            )
+            self.async_write_ha_state()
+
+            async def _reconcile() -> None:
+                await asyncio.sleep(10)
+                await self.coordinator.async_request_refresh()
+                if pending := self.coordinator._vtm_pending.get(self.vin):
+                    remaining = max(
+                        deadline for _, deadline in pending.values()
+                    ) - monotonic()
+                    await asyncio.sleep(max(0, remaining))
+                    await self.coordinator.async_request_refresh()
+
+            if previous := self.coordinator._vtm_reconcile_tasks.get(self.vin):
+                previous.cancel()
+            task = self.coordinator.entry.async_create_background_task(
+                self.hass,
+                _reconcile(),
+                f"Reconcile refrigeration box {self.vin}",
+            )
+            self.coordinator._vtm_reconcile_tasks[self.vin] = task
+            task.add_done_callback(
+                lambda done: self.coordinator._vtm_reconcile_tasks.pop(
+                    self.vin, None
+                )
+                if self.coordinator._vtm_reconcile_tasks.get(self.vin) is done
+                else None
             )

--- a/custom_components/zeekr_ev/manifest.json
+++ b/custom_components/zeekr_ev/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Fryyyyy/zeekr_homeassistant/issues",
   "requirements": [
-    "zeekr_ev_api>=0.1.14"
+    "zeekr_ev_api>=0.1.15"
   ],
   "version": "20260720"
 }

--- a/custom_components/zeekr_ev/number.py
+++ b/custom_components/zeekr_ev/number.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+from math import isfinite
 
 from homeassistant.components.number import NumberEntity, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, VTM_MAX_DURATION, VTM_MIN_DURATION
 from .coordinator import ZeekrCoordinator
-from .entity import ZeekrEntity
+from .entity import (
+    setup_refrigeration_box_discovery,
+    ZeekrEntity,
+    ZeekrRefrigerationBoxEntity,
+)
 
 
 async def async_setup_entry(
@@ -48,9 +54,15 @@ async def async_setup_entry(
             "steering_wheel_duration",
         ),
     ]
-
     for vehicle in coordinator.vehicles:
         entities.append(ZeekrChargingLimitNumber(coordinator, vehicle.vin))
+    setup_refrigeration_box_discovery(
+        coordinator,
+        entry,
+        async_add_entities,
+        entities,
+        ZeekrRefrigerationBoxDurationNumber,
+    )
 
     async_add_entities(entities)
 
@@ -186,3 +198,40 @@ class ZeekrChargingLimitNumber(ZeekrEntity, RestoreNumber):
             await self.coordinator.async_request_refresh()
 
         self.hass.async_create_task(_reconcile())
+
+
+class ZeekrRefrigerationBoxDurationNumber(
+    ZeekrRefrigerationBoxEntity,
+    NumberEntity,
+):
+    """Refrigeration-box run timer."""
+
+    _attr_name = "Refrigeration Box Timer"
+    _attr_icon = "mdi:timer-outline"
+    _attr_native_min_value = VTM_MIN_DURATION / 60
+    _attr_native_max_value = VTM_MAX_DURATION / 60
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+
+    def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
+        """Initialise the refrigeration-box timer."""
+        super().__init__(coordinator, vin)
+        self._attr_unique_id = f"{vin}_refrigeration_box_timer"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the API duration in hours."""
+        _, setting = self._vtm_state()
+        return float(setting["duration"]) / 60 if setting else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the run timer while preserving all other VTM state."""
+        if (
+            not isfinite(value)
+            or not self.native_min_value <= value <= self.native_max_value
+        ):
+            raise HomeAssistantError(
+                f"Timer must be between {self.native_min_value:g} and "
+                f"{self.native_max_value:g} hours"
+            )
+        await self._async_write_vtm(duration=round(value * 60))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,10 @@ def mock_config_entry():
             }
             self.entry_id = "test_entry_id"
             self.title = "Test Entry"
+            self.unload_callbacks = []
+
+        def async_on_unload(self, callback):
+            self.unload_callbacks.append(callback)
 
     return MockConfigEntry()
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,7 +1,12 @@
 from unittest.mock import MagicMock, AsyncMock
 import pytest
-from homeassistant.components.climate import HVACMode
-from custom_components.zeekr_ev.climate import ZeekrClimate, async_setup_entry
+from homeassistant.components.climate import ClimateEntityFeature, HVACMode
+from homeassistant.exceptions import HomeAssistantError
+from custom_components.zeekr_ev.climate import (
+    ZeekrClimate,
+    ZeekrRefrigerationBoxClimate,
+    async_setup_entry,
+)
 from custom_components.zeekr_ev.const import DOMAIN
 
 
@@ -17,11 +22,29 @@ class MockCoordinator:
     def __init__(self, data):
         self.data = data
         self.vehicles = {}
+        self.entry = MagicMock()
+        self.entry.async_create_background_task.side_effect = (
+            lambda hass, coro, name: hass.async_create_task(coro)
+        )
+        self.request_stats = MagicMock()
+        self.request_stats.async_inc_request = AsyncMock()
         self.async_inc_invoke = AsyncMock()
         self.ac_duration = 15
+        self.last_update_success = True
+        self.vtm_locks = {}
+        self._vtm_pending = {}
+        self._vtm_reconcile_tasks = {}
+        self._last_secondary = {}
+        self._secondary_stale_count = {}
+        self._cache_vtm_status = MagicMock()
+        self.listeners = []
 
     def get_vehicle_by_vin(self, vin):
         return self.vehicles.get(vin)
+
+    def async_add_listener(self, callback):
+        self.listeners.append(callback)
+        return MagicMock()
 
     async def async_request_refresh(self):
         pass
@@ -127,17 +150,28 @@ async def test_climate_device_info(hass):
 
 @pytest.mark.asyncio
 async def test_climate_async_setup_entry(hass, mock_config_entry):
-    coordinator = MockCoordinator({"VIN1": {}})
+    coordinator = MockCoordinator(
+        {
+            "SUPPORTED": {"vtmStatus": _vtm_status()},
+            "UNSUPPORTED": {},
+        }
+    )
     hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
 
     async_add_entities = MagicMock()
 
     await async_setup_entry(hass, mock_config_entry, async_add_entities)
 
-    assert async_add_entities.called
-    # Check types
-    types = [type(e) for e in async_add_entities.call_args[0][0]]
-    assert ZeekrClimate in types
+    entities = async_add_entities.call_args.args[0]
+    assert [entity.vin for entity in entities if isinstance(entity, ZeekrClimate)] == [
+        "SUPPORTED",
+        "UNSUPPORTED",
+    ]
+    assert [
+        entity.vin
+        for entity in entities
+        if isinstance(entity, ZeekrRefrigerationBoxClimate)
+    ] == ["SUPPORTED"]
 
 
 @pytest.mark.asyncio
@@ -173,3 +207,263 @@ async def test_climate_attributes(hass):
     initial_data[vin]["additionalVehicleStatus"]["climateStatus"]["updateTime"] = "invalid"
     attrs = climate.extra_state_attributes
     assert "last_updated" not in attrs
+
+
+def _vtm_status(active="1", temp="3.0", duration="1440"):
+    return {
+        "activeStatus": active,
+        "currentTemperature": "2.0",
+        "vtmTsActive": "false",
+        "vtmModel": {
+            "setting": [
+                {
+                    "temp": temp,
+                    "duration": duration,
+                }
+            ]
+        },
+    }
+
+
+def _refrigeration_climate(status=None):
+    vin = "VIN1"
+    status = status or _vtm_status()
+    coordinator = MockCoordinator(
+        {vin: {"vtmStatus": status}}
+    )
+    vehicle = MagicMock()
+    vehicle.get_vtm_status.return_value = status
+    vehicle.do_remote_control.return_value = True
+    coordinator.vehicles[vin] = vehicle
+    climate = ZeekrRefrigerationBoxClimate(coordinator, vin)
+    climate.hass = DummyHass()
+    climate.hass.async_create_task = MagicMock()
+    climate.async_write_ha_state = MagicMock()
+    return climate, coordinator, vehicle
+
+
+def test_refrigeration_climate_properties():
+    climate, coordinator, _ = _refrigeration_climate()
+
+    assert climate.available
+    assert climate.hvac_mode == HVACMode.COOL
+    assert climate.current_temperature == 2.0
+    assert climate.target_temperature == 3.0
+    assert climate.min_temp == -15
+    assert climate.max_temp == 20
+
+    coordinator.data["VIN1"]["vtmStatus"] = _vtm_status(temp="35.0")
+    assert climate.hvac_mode == HVACMode.HEAT
+    assert climate.min_temp == 35
+    assert climate.max_temp == 50
+
+    coordinator.data["VIN1"]["vtmStatus"]["activeStatus"] = "0"
+    assert climate.hvac_mode == HVACMode.OFF
+    assert climate.min_temp == 35
+    assert climate.max_temp == 50
+
+    coordinator.data["VIN1"]["vtmStatus"]["currentTemperature"] = "nan"
+    assert climate.current_temperature is None
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_climate_modes_and_power_actions():
+    climate, coordinator, vehicle = _refrigeration_climate(
+        _vtm_status(temp="3.0", duration="1320")
+    )
+    vehicle.get_vtm_status.return_value = _vtm_status(
+        temp="40.0", duration="1320"
+    )
+    power_features = (
+        ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
+    )
+    assert climate.supported_features & power_features == power_features
+
+    await climate.async_set_hvac_mode(HVACMode.HEAT)
+    assert vehicle.do_remote_control.call_args.args == (
+        "start",
+        "ZAJ",
+        {
+            "serviceParameters": [
+                {"key": "temp", "value": "40.0"},
+                {"key": "duration", "value": "1320"},
+                {"key": "zaj.ts", "value": "false"},
+            ]
+        },
+    )
+    assert climate.hvac_mode == HVACMode.HEAT
+
+    await climate.async_set_hvac_mode(HVACMode.COOL)
+    assert vehicle.do_remote_control.call_args.args[2]["serviceParameters"] == [
+        {"key": "temp", "value": "3.0"},
+        {"key": "duration", "value": "1320"},
+        {"key": "zaj.ts", "value": "false"},
+    ]
+    assert climate.hvac_mode == HVACMode.COOL
+
+    await climate.async_turn_off()
+    assert vehicle.do_remote_control.call_args.args[0] == "stop"
+    assert vehicle.do_remote_control.call_args.args[2]["serviceParameters"] == [
+        {"key": "temp", "value": "3.0"},
+        {"key": "duration", "value": "1320"},
+        {"key": "zaj.ts", "value": "false"},
+    ]
+    assert coordinator.data["VIN1"]["vtmStatus"]["activeStatus"] == "0"
+
+    await climate.async_turn_on()
+    assert vehicle.do_remote_control.call_args.args == (
+        "start",
+        "ZAJ",
+        {
+            "serviceParameters": [
+                {"key": "temp", "value": "3.0"},
+                {"key": "duration", "value": "1320"},
+                {"key": "zaj.ts", "value": "false"},
+            ]
+        },
+    )
+    assert climate.hvac_mode == HVACMode.COOL
+
+    for call in climate.hass.async_create_task.call_args_list:
+        call.args[0].close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [False, RuntimeError("offline")],
+    ids=["false", "exception"],
+)
+async def test_refrigeration_climate_rejects_failed_command(failure):
+    climate, coordinator, vehicle = _refrigeration_climate()
+    if isinstance(failure, Exception):
+        vehicle.do_remote_control.side_effect = failure
+    else:
+        vehicle.do_remote_control.return_value = failure
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Refrigeration-box command failed",
+    ) as error:
+        await climate.async_set_temperature(temperature=4)
+
+    if isinstance(failure, Exception):
+        assert error.value.__cause__ is failure
+    assert (
+        coordinator.data["VIN1"]["vtmStatus"]["vtmModel"]["setting"][0]["temp"]
+        == "3.0"
+    )
+    climate.async_write_ha_state.assert_not_called()
+    climate.hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("temperature", [-16, 21, 35, float("nan"), float("inf")])
+async def test_refrigeration_climate_rejects_invalid_cooling_target(temperature):
+    climate, _, vehicle = _refrigeration_climate()
+
+    with pytest.raises(HomeAssistantError):
+        await climate.async_set_temperature(temperature=temperature)
+
+    vehicle.do_remote_control.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_climate_is_added_after_late_discovery(
+    hass,
+    mock_config_entry,
+):
+    coordinator = MockCoordinator({"VIN1": {}})
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+    coordinator.data["VIN1"]["vtmStatus"] = _vtm_status()
+    coordinator.listeners[0]()
+    coordinator.listeners[0]()
+
+    refrigeration_entities = [
+        entity
+        for call in async_add_entities.call_args_list
+        for entity in call.args[0]
+        if isinstance(entity, ZeekrRefrigerationBoxClimate)
+    ]
+    assert [entity.vin for entity in refrigeration_entities] == ["VIN1"]
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_write_merges_and_publishes_fresh_status():
+    climate, coordinator, vehicle = _refrigeration_climate(
+        _vtm_status(temp="2.0", duration="300")
+    )
+    fresh = _vtm_status(temp="5.0", duration="600.0")
+    fresh["vtmTsActive"] = "true"
+    vehicle.get_vtm_status.return_value = fresh
+
+    await climate.async_set_temperature(temperature=4)
+
+    vehicle.do_remote_control.assert_called_once_with(
+        "start",
+        "ZAJ",
+        {
+            "serviceParameters": [
+                {"key": "temp", "value": "4.0"},
+                {"key": "duration", "value": "600"},
+                {"key": "zaj.ts", "value": "true"},
+            ]
+        },
+    )
+    assert fresh["vtmModel"]["setting"][0] == {
+        "temp": "4.0",
+        "duration": "600",
+    }
+    coordinator._cache_vtm_status.assert_called_once_with("VIN1", fresh)
+    assert coordinator.data["VIN1"]["vtmStatus"] is fresh
+    assert coordinator._last_secondary["VIN1"]["vtmStatus"] is fresh
+    coordinator.request_stats.async_inc_request.assert_awaited_once()
+    climate.async_write_ha_state.assert_called_once()
+    climate.hass.async_create_task.call_args.args[0].close()
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_start_reuses_cached_off_settings():
+    climate, coordinator, vehicle = _refrigeration_climate(
+        _vtm_status(active="0", temp="4.0", duration="1320")
+    )
+    vehicle.get_vtm_status.return_value = {"activeStatus": "0"}
+
+    await climate.async_set_hvac_mode(HVACMode.COOL)
+
+    vehicle.do_remote_control.assert_called_once_with(
+        "start",
+        "ZAJ",
+        {
+            "serviceParameters": [
+                {"key": "temp", "value": "4.0"},
+                {"key": "duration", "value": "1320"},
+                {"key": "zaj.ts", "value": "false"},
+            ]
+        },
+    )
+    assert climate.hvac_mode == HVACMode.COOL
+    assert climate.target_temperature == 4.0
+    assert climate.current_temperature is None
+    assert (
+        coordinator.data["VIN1"]["vtmStatus"]["vtmModel"]["setting"][0][
+            "duration"
+        ]
+        == "1320"
+    )
+    climate.hass.async_create_task.call_args.args[0].close()
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_write_rejects_failed_fresh_status_fetch():
+    climate, coordinator, vehicle = _refrigeration_climate()
+    vehicle.get_vtm_status.side_effect = RuntimeError("offline")
+
+    with pytest.raises(HomeAssistantError, match="unavailable"):
+        await climate.async_set_temperature(temperature=4)
+
+    coordinator.request_stats.async_inc_request.assert_awaited_once()
+    vehicle.do_remote_control.assert_not_called()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -380,6 +380,8 @@ def _coordinator_with_vehicle(vehicle):
     coordinator.request_stats = MagicMock()
     coordinator.request_stats.async_load = AsyncMock()
     coordinator.request_stats.async_inc_request = AsyncMock()
+    coordinator._vtm_store = MagicMock()
+    coordinator._vtm_store.async_load = AsyncMock(return_value=None)
     return coordinator
 
 
@@ -508,6 +510,354 @@ async def test_no_carry_forward_without_a_previous_value():
     try:
         _, data = await coordinator._async_update_vehicle(vehicle)
         assert "journeyLog" not in data
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+def _vtm_status(temp="3.0", duration="1440"):
+    """Return a usable refrigeration-box status payload."""
+    return {
+        "activeStatus": "1",
+        "currentTemperature": "2.0",
+        "vtmTsActive": "false",
+        "vtmModel": {
+            "setting": [
+                {
+                    "temp": temp,
+                    "duration": duration,
+                }
+            ]
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_vtm_status_is_discovered_and_polled():
+    """A usable VTM response enables ongoing polling for that VIN."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(return_value=_vtm_status())
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, first = await coordinator._async_update_vehicle(vehicle)
+        _, second = await coordinator._async_update_vehicle(vehicle)
+
+        assert first["vtmStatus"] == _vtm_status()
+        assert second["vtmStatus"] == _vtm_status()
+        assert vehicle.get_vtm_status.call_count == 2
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_off_vtm_status_keeps_cached_setting():
+    """An off response keeps the last target and timer, not measured temperature."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(
+        side_effect=[
+            _vtm_status(temp="4.0", duration="1320"),
+            {"activeStatus": "0"},
+        ]
+    )
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, first = await coordinator._async_update_vehicle(vehicle)
+        _, second = await coordinator._async_update_vehicle(vehicle)
+
+        assert first["vtmStatus"]["activeStatus"] == "1"
+        assert second["vtmStatus"] == {
+            "activeStatus": "0",
+            "vtmTsActive": "false",
+            "vtmModel": {
+                "setting": [
+                    {
+                        "temp": "4.0",
+                        "duration": "1320",
+                    }
+                ]
+            },
+        }
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_off_vtm_status_prefers_fresh_setting_to_cache():
+    """Fresh off-state controls win when only the timer flag is omitted."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(
+        side_effect=[
+            _vtm_status(temp="4.0", duration="1320"),
+            {
+                "activeStatus": "0",
+                "vtmModel": {
+                    "setting": [{"temp": "5.0", "duration": "600"}]
+                },
+            },
+        ]
+    )
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        await coordinator._async_update_vehicle(vehicle)
+        _, second = await coordinator._async_update_vehicle(vehicle)
+
+        assert second["vtmStatus"]["vtmTsActive"] == "false"
+        assert second["vtmStatus"]["vtmModel"]["setting"][0] == {
+            "temp": "5.0",
+            "duration": "600",
+        }
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_vtm_setting_survives_coordinator_restart():
+    """Persisted controls let an off accessory be rediscovered after restart."""
+    first_vehicle = _vehicle_with_journey_log()
+    first_vehicle.get_vtm_status = MagicMock(
+        return_value=_vtm_status(temp="4.0", duration="1320")
+    )
+    first = _coordinator_with_vehicle(first_vehicle)
+
+    second_vehicle = _vehicle_with_journey_log()
+    second_vehicle.get_vtm_status = MagicMock(
+        return_value={"activeStatus": "0"}
+    )
+    second = _coordinator_with_vehicle(second_vehicle)
+
+    try:
+        await first._async_update_vehicle(first_vehicle)
+        saved = first._vtm_store.async_delay_save.call_args.args[0]()
+        second._vtm_store.async_load.return_value = saved
+
+        await second.async_init_stats()
+        _, data = await second._async_update_vehicle(second_vehicle)
+
+        assert data["vtmStatus"] == {
+            "activeStatus": "0",
+            "vtmTsActive": "false",
+            "vtmModel": {
+                "setting": [{"temp": "4.0", "duration": "1320"}]
+            },
+        }
+    finally:
+        for coordinator in (first, second):
+            if coordinator._unsub_reset:
+                coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_persisted_vtm_setting_keeps_probing_after_empty_responses():
+    """A previously fitted accessory remains eligible for later discovery."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(
+        side_effect=[{}, {}, {}, _vtm_status(temp="4.0", duration="1320")]
+    )
+    coordinator = _coordinator_with_vehicle(vehicle)
+    coordinator._vtm_store.async_load.return_value = {
+        vehicle.vin: _vtm_status(temp="4.0", duration="1320")
+    }
+
+    try:
+        await coordinator.async_init_stats()
+        results = [
+            await coordinator._async_update_vehicle(vehicle)
+            for _ in range(4)
+        ]
+
+        assert all("vtmStatus" not in data for _, data in results[:3])
+        assert results[3][1]["vtmStatus"] == _vtm_status(
+            temp="4.0", duration="1320"
+        )
+        assert vehicle.get_vtm_status.call_count == 4
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_initial_off_vtm_status_keeps_probing():
+    """An explicit off response is not evidence that the accessory is absent."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(return_value={"activeStatus": "0"})
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        results = [
+            await coordinator._async_update_vehicle(vehicle)
+            for _ in range(4)
+        ]
+
+        assert all("vtmStatus" not in data for _, data in results)
+        assert vehicle.get_vtm_status.call_count == 4
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        {},
+        {"vtmModel": {"setting": []}},
+        {"vtmModel": {"setting": [{"temp": "unknown", "duration": "1440"}]}},
+        {
+            "vtmTsActive": "false",
+            "vtmModel": {"setting": [{"temp": "3.0", "duration": "1440"}]},
+        },
+        {
+            "activeStatus": "1",
+            "vtmModel": {"setting": [{"temp": "3.0", "duration": "1440"}]},
+        },
+        _vtm_status(temp="-16"),
+        _vtm_status(temp="21"),
+        _vtm_status(temp="51"),
+        _vtm_status(temp=True),
+        _vtm_status(duration="59"),
+        _vtm_status(duration="600.5"),
+        _vtm_status(duration="1441"),
+        _vtm_status(duration=True),
+    ],
+)
+async def test_unusable_initial_vtm_status_disables_after_three_polls(response):
+    """Three unusable responses opt that VIN out until reload."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(return_value=response)
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        results = [
+            await coordinator._async_update_vehicle(vehicle)
+            for _ in range(4)
+        ]
+
+        assert all("vtmStatus" not in data for _, data in results)
+        assert vehicle.get_vtm_status.call_count == 3
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_vtm_poll_holds_write_lock_until_update_is_ready():
+    """A pending whole-vehicle poll must not publish over a VTM write."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(return_value=_vtm_status())
+
+    def get_status():
+        return {}
+
+    vehicle.get_status = get_status
+    coordinator = _coordinator_with_vehicle(vehicle)
+    coordinator.vehicles = [vehicle]
+    status_started = asyncio.Event()
+    release_status = asyncio.Event()
+    write_acquired = asyncio.Event()
+    visible_data = None
+
+    async def executor(func, *args):
+        if func is get_status:
+            status_started.set()
+            await release_status.wait()
+        return func(*args)
+
+    coordinator.hass.async_add_executor_job = executor
+
+    async def take_write_lock():
+        nonlocal visible_data
+        lock = coordinator.vtm_locks.setdefault(vehicle.vin, asyncio.Lock())
+        async with lock:
+            visible_data = coordinator.data
+            write_acquired.set()
+
+    poll = asyncio.create_task(coordinator._async_update_data())
+    await status_started.wait()
+    write = asyncio.create_task(take_write_lock())
+    await asyncio.sleep(0)
+
+    try:
+        assert not write_acquired.is_set()
+    finally:
+        release_status.set()
+        await asyncio.gather(poll, write)
+        assert visible_data == poll.result()
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_failed_initial_vtm_probe_is_retried():
+    """A transient first-probe failure must not hide a fitted accessory."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(
+        side_effect=[Exception("API Error"), _vtm_status()]
+    )
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, first = await coordinator._async_update_vehicle(vehicle)
+        _, second = await coordinator._async_update_vehicle(vehicle)
+
+        assert "vtmStatus" not in first
+        assert second["vtmStatus"] == _vtm_status()
+        assert vehicle.get_vtm_status.call_count == 2
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_vtm_probe_error_breaks_unusable_response_streak():
+    """Only consecutive unusable responses opt a VIN out."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(
+        side_effect=[
+            {},
+            {},
+            Exception("API Error"),
+            {},
+            {},
+            _vtm_status(),
+        ]
+    )
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        results = [
+            await coordinator._async_update_vehicle(vehicle)
+            for _ in range(6)
+        ]
+
+        assert all("vtmStatus" not in data for _, data in results[:5])
+        assert results[5][1]["vtmStatus"] == _vtm_status()
+        assert vehicle.get_vtm_status.call_count == 6
+    finally:
+        if coordinator._unsub_reset:
+            coordinator._unsub_reset()
+
+
+@pytest.mark.asyncio
+async def test_vtm_status_carries_forward_after_discovery():
+    """A malformed later response uses the normal bounded stale-data path."""
+    vehicle = _vehicle_with_journey_log()
+    vehicle.get_vtm_status = MagicMock(
+        side_effect=[_vtm_status(), {"vtmModel": {"setting": []}}]
+    )
+    coordinator = _coordinator_with_vehicle(vehicle)
+
+    try:
+        _, first = await coordinator._async_update_vehicle(vehicle)
+        _, second = await coordinator._async_update_vehicle(vehicle)
+
+        assert second["vtmStatus"] == first["vtmStatus"]
+        assert coordinator._secondary_stale_count[("VIN1", "vtmStatus")] == 1
     finally:
         if coordinator._unsub_reset:
             coordinator._unsub_reset()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,13 +1,26 @@
 import asyncio
+from math import nan
 from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
-from custom_components.zeekr_ev.number import ZeekrChargingLimitNumber, ZeekrConfigNumber
+from homeassistant.exceptions import HomeAssistantError
+from custom_components.zeekr_ev.climate import ZeekrRefrigerationBoxClimate
+from custom_components.zeekr_ev.const import DOMAIN
+from custom_components.zeekr_ev.coordinator import _apply_vtm_pending
+from custom_components.zeekr_ev.number import (
+    ZeekrChargingLimitNumber,
+    ZeekrConfigNumber,
+    ZeekrRefrigerationBoxDurationNumber,
+    async_setup_entry,
+)
 
 
 @pytest.fixture(autouse=True)
 def _instant_sleep():
     """Make the post-write reconcile delay instant in tests."""
-    with patch("custom_components.zeekr_ev.number.asyncio.sleep", new=AsyncMock()):
+    with (
+        patch("custom_components.zeekr_ev.number.asyncio.sleep", new=AsyncMock()),
+        patch("custom_components.zeekr_ev.entity.asyncio.sleep", new=AsyncMock()),
+    ):
         yield
 
 
@@ -15,21 +28,45 @@ class MockVehicle:
     def __init__(self, vin):
         self.vin = vin
         self.do_remote_control = MagicMock()
+        self.get_vtm_status = MagicMock()
+        self.data = {}
 
 
 class MockCoordinator:
     def __init__(self, vehicles):
         self.vehicles = vehicles
         self.data = {v.vin: {} for v in vehicles}
+        self.entry = MagicMock()
+        self.entry.async_create_background_task.side_effect = (
+            lambda hass, coro, name: hass.async_create_task(coro)
+        )
         self.async_inc_invoke = AsyncMock()
         self.async_request_refresh = AsyncMock()
         self.seat_duration = 15
+        self.last_update_success = True
+        self.vtm_locks = {}
+        self._vtm_pending = {}
+        self._vtm_reconcile_tasks = {}
+        self.request_stats = MagicMock()
+        self.request_stats.async_inc_request = AsyncMock()
+        self._last_secondary = {}
+        self._secondary_stale_count = {}
+        self._cache_vtm_status = MagicMock()
+        self.listeners = []
+        for vehicle in vehicles:
+            vehicle.get_vtm_status.side_effect = (
+                lambda vehicle=vehicle: self.data[vehicle.vin].get("vtmStatus")
+            )
 
     def get_vehicle_by_vin(self, vin):
         for v in self.vehicles:
             if v.vin == vin:
                 return v
         return None
+
+    def async_add_listener(self, callback):
+        self.listeners.append(callback)
+        return MagicMock()
 
 
 class DummyConfig:
@@ -181,3 +218,197 @@ async def test_config_number():
     # But we can test that it calls super().async_added_to_hass()
     # Since we can't easily mock the restore logic without full HA environment,
     # we'll skip detailed restoration test but we covered the main logic logic.
+
+
+def _vtm_status(active="1", temp="3.0", duration="300"):
+    return {
+        "activeStatus": active,
+        "currentTemperature": "2.0",
+        "vtmTsActive": "false",
+        "vtmModel": {
+            "setting": [
+                {
+                    "temp": temp,
+                    "duration": duration,
+                }
+            ]
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_rechecks_authoritative_state_at_pending_expiry():
+    vehicle = MockVehicle("VIN1")
+    vehicle.do_remote_control.return_value = True
+    coordinator = MockCoordinator([vehicle])
+    coordinator.data["VIN1"] = {"vtmStatus": _vtm_status()}
+    number = ZeekrRefrigerationBoxDurationNumber(coordinator, "VIN1")
+    number.hass = DummyHass()
+    number.async_write_ha_state = MagicMock()
+    responses = [
+        _vtm_status(duration="300"),
+        _vtm_status(duration="600"),
+    ]
+    now = 0
+    assert number.native_value == 5
+
+    async def refresh():
+        status = responses.pop(0)
+        _apply_vtm_pending(coordinator._vtm_pending, "VIN1", status)
+        coordinator.data["VIN1"]["vtmStatus"] = status
+
+    async def advance(delay):
+        nonlocal now
+        now += delay
+
+    coordinator.async_request_refresh.side_effect = refresh
+    with (
+        patch(
+            "custom_components.zeekr_ev.coordinator.monotonic",
+            side_effect=lambda: now,
+        ),
+        patch(
+            "custom_components.zeekr_ev.entity.monotonic",
+            side_effect=lambda: now,
+        ),
+        patch(
+            "custom_components.zeekr_ev.entity.asyncio.sleep",
+            side_effect=advance,
+        ) as sleep,
+    ):
+        await number.async_set_native_value(22)
+        vehicle.do_remote_control.assert_called_once_with(
+            "start",
+            "ZAJ",
+            {
+                "serviceParameters": [
+                    {"key": "temp", "value": "3.0"},
+                    {"key": "duration", "value": "1320"},
+                    {"key": "zaj.ts", "value": "false"},
+                ]
+            },
+        )
+        assert number.native_value == 22
+        await asyncio.gather(*number.hass.created_tasks)
+
+    assert [call.args[0] for call in sleep.await_args_list] == [10, 20]
+    assert coordinator.async_request_refresh.await_count == 2
+    assert number.native_value == 10
+    assert "VIN1" not in coordinator._vtm_pending
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_duration_setup_requires_usable_vtm(
+    hass,
+    mock_config_entry,
+):
+    supported = MockVehicle("SUPPORTED")
+    unsupported = MockVehicle("UNSUPPORTED")
+    coordinator = MockCoordinator([supported, unsupported])
+    coordinator.data["SUPPORTED"] = {"vtmStatus": _vtm_status()}
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    entities = async_add_entities.call_args.args[0]
+    duration_entities = [
+        entity
+        for entity in entities
+        if isinstance(entity, ZeekrRefrigerationBoxDurationNumber)
+    ]
+    assert [entity.vin for entity in duration_entities] == ["SUPPORTED"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [0, 25, nan])
+async def test_refrigeration_duration_rejects_invalid_value(value):
+    vehicle = MockVehicle("VIN1")
+    coordinator = MockCoordinator([vehicle])
+    coordinator.data["VIN1"] = {"vtmStatus": _vtm_status()}
+    number = ZeekrRefrigerationBoxDurationNumber(coordinator, "VIN1")
+    number.hass = DummyHass()
+
+    with pytest.raises(HomeAssistantError):
+        await number.async_set_native_value(value)
+
+    vehicle.do_remote_control.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refrigeration_writes_do_not_clobber_each_other():
+    vehicle = MockVehicle("VIN1")
+    vehicle.do_remote_control.return_value = True
+    coordinator = MockCoordinator([vehicle])
+    coordinator.data["VIN1"] = {"vtmStatus": _vtm_status()}
+    vehicle.get_vtm_status.side_effect = [_vtm_status(), _vtm_status()]
+
+    reconcile_started = asyncio.Event()
+    now = 0
+    refreshed = []
+
+    async def advance(delay):
+        nonlocal now
+        if not reconcile_started.is_set():
+            reconcile_started.set()
+            await asyncio.Future()
+        now += delay
+
+    responses = [
+        _vtm_status(),
+        _vtm_status(temp="4.0", duration="1320"),
+    ]
+
+    async def refresh():
+        status = responses.pop(0)
+        _apply_vtm_pending(coordinator._vtm_pending, "VIN1", status)
+        refreshed.append((now, status["vtmModel"]["setting"][0].copy()))
+        coordinator.data["VIN1"]["vtmStatus"] = status
+
+    hass = DummyHass()
+    climate = ZeekrRefrigerationBoxClimate(coordinator, "VIN1")
+    duration = ZeekrRefrigerationBoxDurationNumber(coordinator, "VIN1")
+    climate.hass = hass
+    duration.hass = hass
+    climate.async_write_ha_state = MagicMock()
+    duration.async_write_ha_state = MagicMock()
+    coordinator.async_request_refresh.side_effect = refresh
+
+    with (
+        patch(
+            "custom_components.zeekr_ev.coordinator.monotonic",
+            side_effect=lambda: now,
+        ),
+        patch(
+            "custom_components.zeekr_ev.entity.monotonic",
+            side_effect=lambda: now,
+        ),
+        patch(
+            "custom_components.zeekr_ev.entity.asyncio.sleep",
+            side_effect=advance,
+        ),
+    ):
+        await climate.async_set_temperature(temperature=4)
+        first_reconcile = hass.created_tasks[-1]
+        await reconcile_started.wait()
+        now = 25
+        await duration.async_set_native_value(22)
+        latest_reconcile = hass.created_tasks[-1]
+
+        assert vehicle.do_remote_control.call_args_list[1].args[2][
+            "serviceParameters"
+        ] == [
+            {"key": "temp", "value": "4.0"},
+            {"key": "duration", "value": "1320"},
+            {"key": "zaj.ts", "value": "false"},
+        ]
+        assert coordinator._vtm_reconcile_tasks["VIN1"] is latest_reconcile
+        await asyncio.gather(first_reconcile, return_exceptions=True)
+        assert first_reconcile.cancelled()
+        await latest_reconcile
+
+        assert refreshed == [
+            (35, {"temp": "4.0", "duration": "1320"}),
+            (55, {"temp": "4.0", "duration": "1320"}),
+        ]
+        assert "VIN1" not in coordinator._vtm_reconcile_tasks


### PR DESCRIPTION
Adds refrigeration-box discovery, status polling and Home Assistant controls for vehicles returning usable VTM data.

Closes #141.

Requires `zeekr_ev_api>=0.1.15`, which includes the VTM status support added by [Fryyyyy/zeekr_ev_api#43](https://github.com/Fryyyyy/zeekr_ev_api/pull/43).

## What and why

Vehicles with the refrigeration-box accessory now receive:

- A climate entity exposing current temperature, target temperature, off, cooling, heating and native turn-on/turn-off actions.
- A number entity exposing the configured run duration in hours.
- VTM status polling and ZAJ control through the existing remote-control API.

Entities are discovered from a validated `vtmModel.setting` response rather than the vehicle capability flag, since we could not confirm whether that flag means the accessory is physically fitted or merely supported by the model.

## Review notes

- Cooling and heating have disjoint target ranges (`-15–20 °C` and `35–50 °C`). The VTM response has no explicit mode, so mode is inferred from the target range. Switching modes retains an in-range target or selects the app defaults of 3 °C and 50 °C.
- Each write refreshes the VTM state and resends the complete temperature, duration and `zaj.ts` snapshot so changing one field does not clobber the others.
- Writes are serialised per VIN and briefly overlaid locally while the backend catches up, followed by reconciliation polls.
- Off responses may omit their settings. The last validated target, duration and thermostatic setting are therefore cached in HA storage, allowing off-state entities and native turn-on to retain the configured values across restart.
- Unknown VINs stop VTM probing after three consecutive unusable responses. API errors and explicit off responses do not count towards that limit, and a VIN with validated persisted settings remains eligible.
- The API duration represents the configured run duration, not a remaining-time countdown. It is exposed as a 1–24 hour value in hourly steps.
- Accessory-negative behaviour on the same vehicle model remains unverified, which is why discovery is deliberately conservative.

## Testing

- Full integration test suite: 145 passed with 68.79% coverage.
- Pre-commit, flake8 and mypy all pass.
- The implementation was deployed to Home Assistant 2026.8.3 and tested against a Zeekr 7X with the refrigeration box fitted.
- Live testing covered discovery, current and target temperature, cooling and heating, duration changes, power off/on, preservation of settings while off, and restoration across an HA restart.
