### PR TITLE
Add Front Hood cover with remote release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a custom integration for Zeekr Electric Vehicles for Home Assistant. It 
 - **Climate**: Control Heating / Cooling Vents & Seats and Steering Wheel.
 - **Sensors**: Battery Level, Range, Odometer, Interior Temperature, Tire Pressures, Charging Power, Voltage, Speed.
 - **Binary Sensors**: Charging Status, Plugged In Status, Doors, Tyre Warnings.
+- **Covers**: Open the Front Hood and control the Sunshade and All Windows.
 - **Buttons**: Flash blinkers, enable/disable Sentry Mode.
 - **Locks**: Door and Trunk Lock.
 - **Device Tracker**: Location tracking.

--- a/custom_components/zeekr_ev/__init__.py
+++ b/custom_components/zeekr_ev/__init__.py
@@ -42,11 +42,6 @@ ATTR_VIN = "vin"
 ATTR_TRIP_ID = "trip_id"
 ATTR_TRIP_REPORT_TIME = "trip_report_time"
 
-LEGACY_FRONT_HOOD_ENTITIES = {
-    ("binary_sensor", "_hood_open"),
-    ("lock", "_engineHoodOpenStatus"),
-}
-
 # Service schema
 SERVICE_GET_TRIP_TRACKPOINTS_SCHEMA = vol.Schema(
     {
@@ -55,6 +50,13 @@ SERVICE_GET_TRIP_TRACKPOINTS_SCHEMA = vol.Schema(
         vol.Required(ATTR_TRIP_REPORT_TIME): cv.positive_int,
     }
 )
+
+# Entity registry entries superseded by the Front Hood cover (config entry 1.1 -> 1.2)
+# Format: (entity domain, unique_id suffix)
+LEGACY_FRONT_HOOD_ENTITIES = {
+    ("binary_sensor", "_hood_open"),
+    ("lock", "_engineHoodOpenStatus"),
+}
 
 
 def get_zeekr_client_class(use_local: bool = False):
@@ -89,8 +91,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Remove superseded front hood entities from the entity registry."""
+    """Migrate old config entries."""
+    _LOGGER.debug(
+        "Migrating config entry from version %s.%s", entry.version, entry.minor_version
+    )
+
     if entry.version == 1 and entry.minor_version < 2:
+        # 1.1 -> 1.2: the "Hood open" binary sensor and "Hood (closed = locked)" lock
+        # were replaced by the Front Hood cover, so drop their registry entries.
         registry = er.async_get(hass)
         for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
             if entity.platform != DOMAIN:
@@ -99,9 +107,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entity.domain == domain and entity.unique_id.endswith(unique_id_suffix)
                 for domain, unique_id_suffix in LEGACY_FRONT_HOOD_ENTITIES
             ):
+                _LOGGER.info(
+                    "Removing %s, superseded by the Front Hood cover", entity.entity_id
+                )
                 registry.async_remove(entity.entity_id)
 
         hass.config_entries.async_update_entry(entry, minor_version=2)
+        _LOGGER.debug("Migration to config entry version 1.2 successful")
 
     return True
 

--- a/custom_components/zeekr_ev/__init__.py
+++ b/custom_components/zeekr_ev/__init__.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 import homeassistant.helpers.config_validation as cv
 
@@ -40,6 +41,11 @@ SERVICE_GET_TRIP_TRACKPOINTS = "get_trip_trackpoints"
 ATTR_VIN = "vin"
 ATTR_TRIP_ID = "trip_id"
 ATTR_TRIP_REPORT_TIME = "trip_report_time"
+
+LEGACY_FRONT_HOOD_ENTITIES = {
+    ("binary_sensor", "_hood_open"),
+    ("lock", "_engineHoodOpenStatus"),
+}
 
 # Service schema
 SERVICE_GET_TRIP_TRACKPOINTS_SCHEMA = vol.Schema(
@@ -79,6 +85,24 @@ def get_zeekr_client_class(use_local: bool = False):
 
 async def async_setup(hass: HomeAssistant, config: ConfigType):
     """Set up this integration using YAML is not supported."""
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Remove superseded front hood entities from the entity registry."""
+    if entry.version == 1 and entry.minor_version < 2:
+        registry = er.async_get(hass)
+        for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
+            if entity.platform != DOMAIN:
+                continue
+            if any(
+                entity.domain == domain and entity.unique_id.endswith(unique_id_suffix)
+                for domain, unique_id_suffix in LEGACY_FRONT_HOOD_ENTITIES
+            ):
+                registry.async_remove(entity.entity_id)
+
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+
     return True
 
 

--- a/custom_components/zeekr_ev/binary_sensor.py
+++ b/custom_components/zeekr_ev/binary_sensor.py
@@ -110,7 +110,6 @@ async def async_setup_entry(
                 "Passenger rear door open",
             ),
             "trunk_open": ("trunkOpenStatus", "Trunk open"),
-            "hood_open": ("engineHoodOpenStatus", "Hood open"),
         }
 
         for key, (field_name, label) in door_fields.items():

--- a/custom_components/zeekr_ev/config_flow.py
+++ b/custom_components/zeekr_ev/config_flow.py
@@ -47,6 +47,7 @@ class ZeekrEVAPIFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
     """Config flow for zeekr_ev_api_integration."""
 
     VERSION = 1
+    MINOR_VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self) -> None:

--- a/custom_components/zeekr_ev/cover.py
+++ b/custom_components/zeekr_ev/cover.py
@@ -41,7 +41,7 @@ async def async_setup_entry(
 
 
 class ZeekrFrontHood(CoordinatorEntity, CoverEntity):
-    """Front hood state and latch-release control."""
+    """Zeekr Front Hood class (open only)."""
 
     _attr_has_entity_name = True
     _attr_device_class = CoverDeviceClass.DOOR
@@ -56,23 +56,27 @@ class ZeekrFrontHood(CoordinatorEntity, CoverEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return whether the front hood is closed."""
-        value = (
-            self.coordinator.data.get(self.vin, {})
-            .get("additionalVehicleStatus", {})
-            .get("drivingSafetyStatus", {})
-            .get("engineHoodOpenStatus")
-        )
-        if value is None:
+        """Return if the front hood is closed."""
+        try:
+            val = (
+                self.coordinator.data.get(self.vin, {})
+                .get("additionalVehicleStatus", {})
+                .get("drivingSafetyStatus", {})
+                .get("engineHoodOpenStatus")
+            )
+            if val is None:
+                return None
+            # "0" is Closed, "1" is Open; anything else is unknown
+            if str(val) == "0":
+                return True
+            if str(val) == "1":
+                return False
             return None
-        if str(value) == "0":
-            return True
-        if str(value) == "1":
-            return False
-        return None
+        except (ValueError, TypeError, AttributeError):
+            return None
 
     async def async_open_cover(self, **kwargs: Any) -> None:
-        """Release the front hood latch."""
+        """Open the front hood."""
         vehicle = self.coordinator.get_vehicle_by_vin(self.vin)
         if not vehicle:
             return
@@ -83,7 +87,7 @@ class ZeekrFrontHood(CoordinatorEntity, CoverEntity):
             "serviceParameters": [
                 {
                     "key": "target",
-                    "value": "hood",
+                    "value": "hood"
                 }
             ]
         }
@@ -92,6 +96,7 @@ class ZeekrFrontHood(CoordinatorEntity, CoverEntity):
         await self.hass.async_add_executor_job(
             vehicle.do_remote_control, command, service_id, setting
         )
+        # No optimistic update; the reported state comes from the car
         await self.coordinator.async_request_refresh()
 
     @property

--- a/custom_components/zeekr_ev/cover.py
+++ b/custom_components/zeekr_ev/cover.py
@@ -35,7 +35,73 @@ async def async_setup_entry(
         for win in ["Driver", "Passenger", "DriverRear", "PassengerRear"]:
             entities.append(ZeekrWindow(coordinator, vin, win, f"Window {win}"))
 
+        entities.append(ZeekrFrontHood(coordinator, vin))
+
     async_add_entities(entities)
+
+
+class ZeekrFrontHood(CoordinatorEntity, CoverEntity):
+    """Front hood state and latch-release control."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = CoverDeviceClass.DOOR
+    _attr_supported_features = CoverEntityFeature.OPEN
+
+    def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
+        """Initialize the cover entity."""
+        super().__init__(coordinator)
+        self.vin = vin
+        self._attr_name = "Front Hood"
+        self._attr_unique_id = f"{vin}_front_hood"
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return whether the front hood is closed."""
+        value = (
+            self.coordinator.data.get(self.vin, {})
+            .get("additionalVehicleStatus", {})
+            .get("drivingSafetyStatus", {})
+            .get("engineHoodOpenStatus")
+        )
+        if value is None:
+            return None
+        if str(value) == "0":
+            return True
+        if str(value) == "1":
+            return False
+        return None
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Release the front hood latch."""
+        vehicle = self.coordinator.get_vehicle_by_vin(self.vin)
+        if not vehicle:
+            return
+
+        command = "start"
+        service_id = "RDU"
+        setting = {
+            "serviceParameters": [
+                {
+                    "key": "target",
+                    "value": "hood",
+                }
+            ]
+        }
+
+        await self.coordinator.async_inc_invoke()
+        await self.hass.async_add_executor_job(
+            vehicle.do_remote_control, command, service_id, setting
+        )
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self.vin)},
+            "name": f"Zeekr {self.vin}",
+            "manufacturer": "Zeekr",
+        }
 
 
 class ZeekrSunshade(CoordinatorEntity, CoverEntity):

--- a/custom_components/zeekr_ev/lock.py
+++ b/custom_components/zeekr_ev/lock.py
@@ -36,7 +36,6 @@ async def async_setup_entry(
         "doorLockStatusDriverRear": ("Driver rear door lock", "drivingSafetyStatus"),
         "doorLockStatusPassengerRear": ("Passenger rear door lock", "drivingSafetyStatus"),
         "trunkLockStatus": ("Trunk lock", "drivingSafetyStatus"),
-        "engineHoodOpenStatus": ("Hood (closed = locked)", "drivingSafetyStatus"),
         "electricParkBrakeStatus": ("Electric park brake", "drivingSafetyStatus"),
         "chargeLidDcAcStatus": ("Charge Lid", "electricVehicleStatus"),
     }

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,8 +1,7 @@
 from unittest.mock import MagicMock, AsyncMock
 import pytest
 from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
-from custom_components.zeekr_ev.cover import ZeekrFrontHood
-from custom_components.zeekr_ev.cover import ZeekrSunshade, ZeekrWindows, ZeekrWindow, async_setup_entry
+from custom_components.zeekr_ev.cover import ZeekrFrontHood, ZeekrSunshade, ZeekrWindows, ZeekrWindow, async_setup_entry
 from custom_components.zeekr_ev.const import DOMAIN
 
 
@@ -267,17 +266,17 @@ async def test_front_hood_open_command(hass):
 
     await hood.async_open_cover()
 
-    coordinator.async_inc_invoke.assert_awaited_once()
-    vehicle.do_remote_control.assert_called_once_with(
+    coordinator.async_inc_invoke.assert_called_once()
+    vehicle.do_remote_control.assert_called_with(
         "start",
         "RDU",
         {
             "serviceParameters": [
                 {
                     "key": "target",
-                    "value": "hood",
+                    "value": "hood"
                 }
             ]
-        },
+        }
     )
-    coordinator.async_request_refresh.assert_awaited_once()
+    coordinator.async_request_refresh.assert_called_once()

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, AsyncMock
 import pytest
+from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
+from custom_components.zeekr_ev.cover import ZeekrFrontHood
 from custom_components.zeekr_ev.cover import ZeekrSunshade, ZeekrWindows, ZeekrWindow, async_setup_entry
 from custom_components.zeekr_ev.const import DOMAIN
 
@@ -110,12 +112,13 @@ async def test_cover_async_setup_entry(hass, mock_config_entry):
     await async_setup_entry(hass, mock_config_entry, async_add_entities)
 
     assert async_add_entities.called
-    # Sunshade + All Windows + 4 Individual Windows = 6
-    assert len(async_add_entities.call_args[0][0]) == 6
+    # Sunshade + All Windows + 4 Individual Windows + Front Hood = 7
+    assert len(async_add_entities.call_args[0][0]) == 7
     entities = async_add_entities.call_args[0][0]
     assert isinstance(entities[0], ZeekrSunshade)
     assert isinstance(entities[1], ZeekrWindows)
     assert isinstance(entities[2], ZeekrWindow)
+    assert isinstance(entities[6], ZeekrFrontHood)
 
 
 @pytest.mark.asyncio
@@ -222,3 +225,59 @@ async def test_zeekr_window_readonly(hass):
     # Ensure no-op commands don't crash
     await window.async_open_cover()
     await window.async_close_cover()
+
+
+def test_front_hood_state_and_features():
+    vin = "VIN1"
+    safety_status = {"engineHoodOpenStatus": "0"}
+    coordinator = MockCoordinator(
+        {
+            vin: {
+                "additionalVehicleStatus": {
+                    "drivingSafetyStatus": safety_status
+                }
+            }
+        }
+    )
+    hood = ZeekrFrontHood(coordinator, vin)
+
+    assert hood.name == "Front Hood"
+    assert hood.unique_id == "VIN1_front_hood"
+    assert hood.device_class == CoverDeviceClass.DOOR
+    assert hood.supported_features == CoverEntityFeature.OPEN
+
+    for value, expected in (("0", True), ("1", False), ("2", None)):
+        safety_status["engineHoodOpenStatus"] = value
+        assert hood.is_closed is expected
+
+    safety_status.clear()
+    assert hood.is_closed is None
+
+
+@pytest.mark.asyncio
+async def test_front_hood_open_command(hass):
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    vehicle.do_remote_control = MagicMock(return_value=True)
+    coordinator = MockCoordinator({vin: {}})
+    coordinator.vehicles[vin] = vehicle
+    coordinator.async_request_refresh = AsyncMock()
+    hood = ZeekrFrontHood(coordinator, vin)
+    hood.hass = hass
+
+    await hood.async_open_cover()
+
+    coordinator.async_inc_invoke.assert_awaited_once()
+    vehicle.do_remote_control.assert_called_once_with(
+        "start",
+        "RDU",
+        {
+            "serviceParameters": [
+                {
+                    "key": "target",
+                    "value": "hood",
+                }
+            ]
+        },
+    )
+    coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,12 +7,22 @@ from custom_components.zeekr_ev.const import DOMAIN
 
 
 class DummyEntry:
-    def __init__(self, data=None, entry_id="entry1"):
+    def __init__(self, data=None, entry_id="entry1", version=1, minor_version=1):
         self.data = data or {}
         self.entry_id = entry_id
+        self.version = version
+        self.minor_version = minor_version
 
     def async_on_unload(self, cb):
         pass
+
+
+class DummyRegistryEntry:
+    def __init__(self, entity_id, domain, unique_id, platform=DOMAIN):
+        self.entity_id = entity_id
+        self.domain = domain
+        self.unique_id = unique_id
+        self.platform = platform
 
 
 @pytest.mark.asyncio
@@ -25,11 +34,15 @@ async def test_async_setup_entry_missing_credentials(hass):
 
 @pytest.mark.asyncio
 async def test_migrate_front_hood_to_cover(hass):
-    entry = SimpleNamespace(entry_id="entry1", version=1, minor_version=1)
+    entry = DummyEntry(version=1, minor_version=1)
     entities = [
-        SimpleNamespace(entity_id="binary_sensor.zeekr_front_hood", domain="binary_sensor", platform=DOMAIN, unique_id="VIN1_hood_open"),
-        SimpleNamespace(entity_id="lock.zeekr_front_hood", domain="lock", platform=DOMAIN, unique_id="VIN1_engineHoodOpenStatus"),
-        SimpleNamespace(entity_id="binary_sensor.other_hood", domain="binary_sensor", platform="other_integration", unique_id="VIN1_hood_open"),
+        DummyRegistryEntry("binary_sensor.zeekr_vin1_hood_open", "binary_sensor", "VIN1_hood_open"),
+        DummyRegistryEntry("lock.zeekr_vin1_hood_closed_locked", "lock", "VIN1_engineHoodOpenStatus"),
+        # Same platform, other entities: must be kept
+        DummyRegistryEntry("binary_sensor.zeekr_vin1_trunk_open", "binary_sensor", "VIN1_trunk_open"),
+        DummyRegistryEntry("lock.zeekr_vin1_trunk_lock", "lock", "VIN1_trunkLockStatus"),
+        # Same unique_id suffix, other integration: must be kept
+        DummyRegistryEntry("binary_sensor.other_hood", "binary_sensor", "VIN1_hood_open", platform="other_integration"),
     ]
     registry = MagicMock()
     hass.config_entries.async_update_entry = MagicMock()
@@ -44,8 +57,8 @@ async def test_migrate_front_hood_to_cover(hass):
         assert await async_migrate_entry(hass, entry) is True
 
     assert [call.args[0] for call in registry.async_remove.call_args_list] == [
-        "binary_sensor.zeekr_front_hood",
-        "lock.zeekr_front_hood",
+        "binary_sensor.zeekr_vin1_hood_open",
+        "lock.zeekr_vin1_hood_closed_locked",
     ]
     hass.config_entries.async_update_entry.assert_called_once_with(
         entry, minor_version=2

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,10 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
-from custom_components.zeekr_ev import async_setup_entry
+
+from custom_components.zeekr_ev import async_migrate_entry, async_setup_entry
+from custom_components.zeekr_ev.const import DOMAIN
 
 
 class DummyEntry:
@@ -16,3 +21,32 @@ async def test_async_setup_entry_missing_credentials(hass):
     entry = DummyEntry(data={})
     res = await async_setup_entry(hass, entry)
     assert res is False
+
+
+@pytest.mark.asyncio
+async def test_migrate_front_hood_to_cover(hass):
+    entry = SimpleNamespace(entry_id="entry1", version=1, minor_version=1)
+    entities = [
+        SimpleNamespace(entity_id="binary_sensor.zeekr_front_hood", domain="binary_sensor", platform=DOMAIN, unique_id="VIN1_hood_open"),
+        SimpleNamespace(entity_id="lock.zeekr_front_hood", domain="lock", platform=DOMAIN, unique_id="VIN1_engineHoodOpenStatus"),
+        SimpleNamespace(entity_id="binary_sensor.other_hood", domain="binary_sensor", platform="other_integration", unique_id="VIN1_hood_open"),
+    ]
+    registry = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    with (
+        patch("custom_components.zeekr_ev.er.async_get", return_value=registry),
+        patch(
+            "custom_components.zeekr_ev.er.async_entries_for_config_entry",
+            return_value=entities,
+        ),
+    ):
+        assert await async_migrate_entry(hass, entry) is True
+
+    assert [call.args[0] for call in registry.async_remove.call_args_list] == [
+        "binary_sensor.zeekr_front_hood",
+        "lock.zeekr_front_hood",
+    ]
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry, minor_version=2
+    )


### PR DESCRIPTION
- Replace the Front Hood binary sensor and lock with an open-only cover.
- Report its state using `engineHoodOpenStatus`.
- Release the hood using `RDU` with `target: hood`.
- Migrate and remove the superseded entities from the entity registry.

The cover is open-only because the hood must be closed physically.