### PR TITLE
Add window ventilation button

### DIFF
--- a/custom_components/zeekr_ev/button.py
+++ b/custom_components/zeekr_ev/button.py
@@ -31,6 +31,7 @@ async def async_setup_entry(
         entities.append(ZeekrForceUpdateButton(coordinator, vehicle.vin))
         entities.append(ZeekrFlashBlinkersButton(coordinator, vehicle.vin))
         entities.append(ZeekrHonkFlashButton(coordinator, vehicle.vin))
+        entities.append(ZeekrVentilateWindowsButton(coordinator, vehicle.vin))
         entities.append(ZeekrParkingComfortDisableButton(coordinator, vehicle.vin))
 
     async_add_entities(entities)
@@ -104,6 +105,42 @@ class ZeekrHonkFlashButton(ZeekrEntity, ButtonEntity):
             vehicle.do_remote_control, command, service_id, setting
         )
         _LOGGER.info("Honk horn and flash blinkers requested for vehicle %s", self.vin)
+
+
+class ZeekrVentilateWindowsButton(ZeekrEntity, ButtonEntity):
+    """Button to ventilate all windows."""
+
+    _attr_icon = "mdi:weather-windy"
+
+    def __init__(self, coordinator: ZeekrCoordinator, vin: str) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator, vin)
+        self._attr_name = "Ventilate Windows"
+        self._attr_unique_id = f"{vin}_ventilate_windows"
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        vehicle = self.coordinator.get_vehicle_by_vin(self.vin)
+        if not vehicle:
+            return
+
+        command = "start"
+        service_id = "RWS"
+        setting = {
+            "serviceParameters": [
+                {
+                    "key": "target",
+                    "value": "ventilate"
+                }
+            ]
+        }
+
+        await self.coordinator.async_inc_invoke()
+        await self.hass.async_add_executor_job(
+            vehicle.do_remote_control, command, service_id, setting
+        )
+        await self.coordinator.async_request_refresh()
+        _LOGGER.info("Window ventilation requested for vehicle %s", self.vin)
 
 
 class ZeekrParkingComfortDisableButton(ZeekrEntity, ButtonEntity):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -3,6 +3,7 @@ import pytest
 from custom_components.zeekr_ev.button import (
     ZeekrFlashBlinkersButton,
     ZeekrHonkFlashButton,
+    ZeekrVentilateWindowsButton,
     ZeekrParkingComfortDisableButton,
     ZeekrForceUpdateButton,
     async_setup_entry,
@@ -100,6 +101,33 @@ async def test_honk_flash_button():
 
 
 @pytest.mark.asyncio
+async def test_ventilate_windows_button():
+    vin = "VIN1"
+    vehicle = MockVehicle(vin)
+    coordinator = MockCoordinator([vehicle])
+
+    button = ZeekrVentilateWindowsButton(coordinator, vin)
+    button.hass = DummyHass()
+
+    await button.async_press()
+
+    coordinator.async_inc_invoke.assert_called_once()
+    vehicle.do_remote_control.assert_called_with(
+        "start",
+        "RWS",
+        {
+            "serviceParameters": [
+                {
+                    "key": "target",
+                    "value": "ventilate"
+                }
+            ]
+        }
+    )
+    coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_parking_comfort_disable_button():
     vin = "VIN1"
     vehicle = MockVehicle(vin)
@@ -161,10 +189,11 @@ async def test_button_async_setup_entry(mock_config_entry):
 
     assert async_add_entities.called
     entities = async_add_entities.call_args[0][0]
-    assert len(entities) == 4
+    assert len(entities) == 5
 
     # Check all button types are present
     assert any(isinstance(e, ZeekrFlashBlinkersButton) for e in entities)
     assert any(isinstance(e, ZeekrHonkFlashButton) for e in entities)
+    assert any(isinstance(e, ZeekrVentilateWindowsButton) for e in entities)
     assert any(isinstance(e, ZeekrParkingComfortDisableButton) for e in entities)
     assert any(isinstance(e, ZeekrForceUpdateButton) for e in entities)


### PR DESCRIPTION
Adds a Ventilate Windows button using the existing `RWS` command while retaining the Windows cover for full open/close.

This follows other integrations which expose ventilation separately when full-open is also supported. 

Tests included.