### PR TITLE
Fix vehicle climate control settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ This is a custom integration for Zeekr Electric Vehicles for Home Assistant. It 
 3. Search for "Zeekr EV".
 4. Enter your Zeekr account email and password.
 
+### Operation durations
+
+AC, seat heating and ventilation, and steering wheel heating durations are stored locally in Home Assistant. They are not synchronized with the mobile app because the car does not report these settings. Each command uses the duration configured in the client that starts it.
+
+New entities default to 15 minutes for AC and seats, and 8 minutes for steering wheel heating. Existing Home Assistant values are carried over to every car during migration (a previous value of 0 becomes 1 minute, the new minimum) and may therefore differ from the mobile app defaults.
+
 ## Tips & Tricks
 
 - **Account**: Create a new account and share your car with the new account to avoid "The account is currently logged in elsewhere"

--- a/custom_components/zeekr_ev/climate.py
+++ b/custom_components/zeekr_ev/climate.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ZeekrClimate(CoordinatorEntity, ClimateEntity):
+class ZeekrClimate(CoordinatorEntity[ZeekrCoordinator], ClimateEntity):
     """Zeekr Climate class."""
 
     _attr_has_entity_name = True
@@ -120,7 +120,7 @@ class ZeekrClimate(CoordinatorEntity, ClimateEntity):
 
         if hvac_mode == HVACMode.HEAT_COOL:
             # Turn ON
-            duration = getattr(self.coordinator, "ac_duration", 15)
+            duration = self.coordinator.operation_durations.get(self.vin, {}).get("ac", 15)
             setting = {
                 "serviceParameters": [
                     {
@@ -150,9 +150,11 @@ class ZeekrClimate(CoordinatorEntity, ClimateEntity):
 
         if setting:
             await self.coordinator.async_inc_invoke()
-            await self.hass.async_add_executor_job(
+            success = await self.hass.async_add_executor_job(
                 vehicle.do_remote_control, command, service_id, setting
             )
+            if not success:
+                raise HomeAssistantError(f"Failed to set climate mode to {hvac_mode}")
 
             # Optimistic update
             self._update_local_state_optimistically(hvac_mode)
@@ -185,11 +187,19 @@ class ZeekrClimate(CoordinatorEntity, ClimateEntity):
         if (temp := kwargs.get("temperature")) is None:
             return
 
+        previous = self._target_temperature
         self._target_temperature = temp
 
         # If currently running, update the temp by sending the command again
         if self.hvac_mode == HVACMode.HEAT_COOL:
-            await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
+            try:
+                await self.async_set_hvac_mode(HVACMode.HEAT_COOL)
+            except Exception:
+                # Rejected by the car, or the request itself failed: don't keep
+                # showing a target it never received (unless a newer call set one)
+                if self._target_temperature == temp:
+                    self._target_temperature = previous
+                raise
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/zeekr_ev/coordinator.py
+++ b/custom_components/zeekr_ev/coordinator.py
@@ -190,10 +190,10 @@ class ZeekrCoordinator(DataUpdateCoordinator):
         self.client = client
         self.entry = entry
         self.vehicles: list[Vehicle] = []
-        # Shared settings for command durations
-        self.seat_duration = 15
-        self.ac_duration = 15
-        self.steering_wheel_duration = 15
+        # Per-VIN command durations in minutes, {vin: {duration_key: n}}; seeded
+        # and updated by number.ZeekrConfigNumber (keys in number.CONFIG_NUMBERS),
+        # read by climate, select and switch when sending a command
+        self.operation_durations: dict[str, dict[str, int]] = {}
         self.request_stats = ZeekrRequestStats(hass)
         self.latest_poll_time: Optional[str] = None  # Track latest poll time
         # Count of consecutive failed status polls per VIN, so carry-forward of

--- a/custom_components/zeekr_ev/number.py
+++ b/custom_components/zeekr_ev/number.py
@@ -3,15 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from math import isfinite
 
-from homeassistant.components.number import NumberEntity, RestoreNumber
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    RestoreNumber,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE, UnitOfTime
+from homeassistant.const import PERCENTAGE, EntityCategory, Platform, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import restore_state
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, VTM_MAX_DURATION, VTM_MIN_DURATION
 from .coordinator import ZeekrCoordinator
@@ -20,6 +26,68 @@ from .entity import (
     ZeekrEntity,
     ZeekrRefrigerationBoxEntity,
 )
+
+_LOGGER = logging.getLogger(__name__)
+
+# Entity key -> (name, operation_durations key, default minutes)
+CONFIG_NUMBERS = {
+    "seat_operation_duration": ("Seat Operation Duration", "seat", 15),
+    "ac_operation_duration": ("AC Operation Duration", "ac", 15),
+    "steering_wheel_heat_duration": ("Steering Wheel Heat Duration", "wheel", 8),
+}
+
+# Operation durations are clamped to this range (minutes)
+MIN_OPERATION_DURATION = 1
+MAX_OPERATION_DURATION = 60
+
+
+def _migrate_legacy_config_numbers(
+    hass: HomeAssistant, entry_id: str, vin: str
+) -> dict[str, int]:
+    """Move the legacy account-wide duration entities onto a vehicle.
+
+    The entity IDs and their history are kept for the given VIN. The restored
+    values are returned so every vehicle can be seeded with them.
+    """
+    registry = er.async_get(hass)
+    restored_states = restore_state.async_get(hass).last_states
+    values: dict[str, int] = {}
+
+    for key, (_name, duration_key, _default_value) in CONFIG_NUMBERS.items():
+        new_unique_id = f"{vin}_{key}"
+        if registry.async_get_entity_id(Platform.NUMBER, DOMAIN, new_unique_id):
+            # Already migrated
+            continue
+
+        old_unique_id = f"{entry_id}_{key}"
+        if entity_id := registry.async_get_entity_id(
+            Platform.NUMBER, DOMAIN, old_unique_id
+        ):
+            # RestoreNumber always stores native_value in extra_data
+            stored_state = restored_states.get(entity_id)
+            native_value = None
+            if stored_state and (extra_data := stored_state.extra_data):
+                native_value = extra_data.as_dict().get("native_value")
+
+            if native_value is not None:
+                try:
+                    values[duration_key] = max(
+                        MIN_OPERATION_DURATION,
+                        min(int(float(native_value)), MAX_OPERATION_DURATION),
+                    )
+                except (TypeError, ValueError):
+                    pass
+
+            _LOGGER.debug(
+                "Migrating %s from unique_id %s to %s (seed value %s)",
+                entity_id,
+                old_unique_id,
+                new_unique_id,
+                values.get(duration_key),
+            )
+            registry.async_update_entity(entity_id, new_unique_id=new_unique_id)
+
+    return values
 
 
 async def async_setup_entry(
@@ -30,31 +98,30 @@ async def async_setup_entry(
     """Set up the number platform."""
     coordinator: ZeekrCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    # We create global configuration numbers, not per vehicle
-    entities: list[NumberEntity] = [
-        ZeekrConfigNumber(
-            coordinator,
+    entities: list[NumberEntity] = []
+
+    legacy_values: dict[str, int] = {}
+    if coordinator.vehicles:
+        # The lowest VIN inherits the legacy account-wide entity IDs; every
+        # vehicle is seeded with the values they held.
+        legacy_values = _migrate_legacy_config_numbers(
+            hass,
             entry.entry_id,
-            "seat_operation_duration",
-            "Seat Operation Duration",
-            "seat_duration",
-        ),
-        ZeekrConfigNumber(
-            coordinator,
-            entry.entry_id,
-            "ac_operation_duration",
-            "AC Operation Duration",
-            "ac_duration",
-        ),
-        ZeekrConfigNumber(
-            coordinator,
-            entry.entry_id,
-            "steering_wheel_heat_duration",
-            "Steering Wheel Heat Duration",
-            "steering_wheel_duration",
-        ),
-    ]
+            min(vehicle.vin for vehicle in coordinator.vehicles),
+        )
+
     for vehicle in coordinator.vehicles:
+        for key, (name, duration_key, default_value) in CONFIG_NUMBERS.items():
+            entities.append(
+                ZeekrConfigNumber(
+                    coordinator,
+                    vehicle.vin,
+                    key,
+                    name,
+                    duration_key,
+                    legacy_values.get(duration_key, default_value),
+                )
+            )
         entities.append(ZeekrChargingLimitNumber(coordinator, vehicle.vin))
     setup_refrigeration_box_discovery(
         coordinator,
@@ -67,12 +134,14 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ZeekrConfigNumber(CoordinatorEntity, RestoreNumber):
+class ZeekrConfigNumber(ZeekrEntity, RestoreNumber):
     """Zeekr Configuration Number class."""
 
     _attr_has_entity_name = True
-    _attr_native_min_value = 0
-    _attr_native_max_value = 15
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = MIN_OPERATION_DURATION
+    _attr_native_max_value = MAX_OPERATION_DURATION
     _attr_native_step = 1
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
     _attr_icon = "mdi:timer-outline"
@@ -80,32 +149,36 @@ class ZeekrConfigNumber(CoordinatorEntity, RestoreNumber):
     def __init__(
         self,
         coordinator: ZeekrCoordinator,
-        entry_id: str,
+        vin: str,
         key: str,
         name: str,
-        coordinator_attr: str,
+        duration_key: str,
+        default_value: int,
     ) -> None:
         """Initialize the number entity."""
-        super().__init__(coordinator)
-        self._coordinator_attr = coordinator_attr
+        super().__init__(coordinator, vin)
+        self._duration_key = duration_key
         self._attr_name = name
-        self._attr_unique_id = f"{entry_id}_{key}"
-        # Set initial value from coordinator default
-        self._attr_native_value = getattr(coordinator, coordinator_attr, 15)
+        self._attr_unique_id = f"{vin}_{key}"
+        durations = coordinator.operation_durations.setdefault(vin, {})
+        self._attr_native_value = durations.setdefault(duration_key, default_value)
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_number_data()
         if last_state and last_state.native_value is not None:
-            self._attr_native_value = last_state.native_value
-            # Update coordinator with restored value
-            setattr(self.coordinator, self._coordinator_attr, int(last_state.native_value))
+            value = max(
+                int(self.native_min_value),
+                min(int(last_state.native_value), int(self.native_max_value)),
+            )
+            self._attr_native_value = value
+            self.coordinator.operation_durations[self.vin][self._duration_key] = value
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        self._attr_native_value = value
-        setattr(self.coordinator, self._coordinator_attr, int(value))
+        self._attr_native_value = int(value)
+        self.coordinator.operation_durations[self.vin][self._duration_key] = int(value)
         self.async_write_ha_state()
 
 

--- a/custom_components/zeekr_ev/select.py
+++ b/custom_components/zeekr_ev/select.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -123,7 +125,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class ZeekrSeatSelect(CoordinatorEntity, SelectEntity):
+class ZeekrSeatSelect(CoordinatorEntity[ZeekrCoordinator], SelectEntity):
     """Zeekr Seat Select class."""
 
     _attr_has_entity_name = True
@@ -205,7 +207,7 @@ class ZeekrSeatSelect(CoordinatorEntity, SelectEntity):
             return
 
         level = OPTION_TO_LEVEL.get(option, 0)
-        duration = getattr(self.coordinator, "seat_duration", 15)
+        duration = self.coordinator.operation_durations.get(self.vin, {}).get("seat", 15)
 
         command = "start"
         service_id = "ZAF"
@@ -228,16 +230,22 @@ class ZeekrSeatSelect(CoordinatorEntity, SelectEntity):
         setting["serviceParameters"] = params
 
         await self.coordinator.async_inc_invoke()
-        await self.hass.async_add_executor_job(
+        success = await self.hass.async_add_executor_job(
             vehicle.do_remote_control, command, service_id, setting
         )
+        if not success:
+            raise HomeAssistantError(f"Failed to set {self._attr_name} to {option}")
 
         # Optimistic update
         self._update_local_state_optimistically(level)
         self.async_write_ha_state()
 
-        # Trigger refresh (might revert if API is slow, but that's expected eventually)
-        await self.coordinator.async_request_refresh()
+        # Delay the refresh: an immediate poll can still return the old level
+        # and revert the optimistic update
+        async def delayed_refresh():
+            await asyncio.sleep(10)
+            await self.coordinator.async_request_refresh()
+        self.hass.async_create_task(delayed_refresh())
 
     def _update_local_state_optimistically(self, level: int):
         """Update the coordinator data to reflect the change immediately."""

--- a/custom_components/zeekr_ev/switch.py
+++ b/custom_components/zeekr_ev/switch.py
@@ -9,6 +9,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -158,7 +159,7 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
             }
         elif self.field == "steering_wheel_heat":
             service_id = "ZAF"
-            duration = getattr(self.coordinator, "steering_wheel_duration", 15)
+            duration = self.coordinator.operation_durations.get(self.vin, {}).get("wheel", 8)
             setting = {
                 "serviceParameters": [
                     {
@@ -192,9 +193,16 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
 
         if setting:
             await self.coordinator.async_inc_invoke()
-            await self.hass.async_add_executor_job(
+            success = await self.hass.async_add_executor_job(
                 vehicle.do_remote_control, command, service_id, setting
             )
+            # Only the commands reworked to carry a per-vehicle duration (AC, seats,
+            # steering wheel) surface a rejection, so here only the steering wheel
+            # raises. Defrost and sentry mode keep their pre-existing optimistic
+            # update (extend the check if that should change); charging has its own
+            # confirmation loop below.
+            if self.field == "steering_wheel_heat" and not success:
+                raise HomeAssistantError(f"Failed to turn on {self._attr_name}")
 
             if self.field == "charging":
                 # Wait for backend confirmation for charging
@@ -300,9 +308,13 @@ class ZeekrSwitch(CoordinatorEntity[ZeekrCoordinator], SwitchEntity):
 
         if setting:
             await self.coordinator.async_inc_invoke()
-            await self.hass.async_add_executor_job(
+            success = await self.hass.async_add_executor_job(
                 vehicle.do_remote_control, command, service_id, setting
             )
+            # See async_turn_on: only the steering wheel raises on rejection (scoped
+            # to the duration-carrying commands)
+            if self.field == "steering_wheel_heat" and not success:
+                raise HomeAssistantError(f"Failed to turn off {self._attr_name}")
             if self.field == "charging":
                 # Wait for backend confirmation that charging has stopped — symmetric
                 # with async_turn_on. An immediate coordinator refresh can still read the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import restore_state
 
 
 class DummyConfigEntries:
@@ -24,6 +29,14 @@ class DummyHass:
         self.config_entries = DummyConfigEntries()
         self.config = DummyConfig()
         self.loop = asyncio.get_event_loop()
+        # er.async_get / restore_state.async_get are @singleton accessors keyed on
+        # hass.data, so pre-seeding these keys short-circuits them and the number
+        # platform migration runs without a real Home Assistant. spec= makes a
+        # wrong registry method name raise instead of returning a truthy MagicMock.
+        registry = MagicMock(spec=er.EntityRegistry)
+        registry.async_get_entity_id.return_value = None
+        self.data[er.DATA_REGISTRY] = registry
+        self.data[restore_state.DATA_RESTORE_STATE] = SimpleNamespace(last_states={})
 
     async def async_add_executor_job(self, func, *args, **kwargs):
         # Run synchronous callable in test loop

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -8,6 +8,7 @@ from custom_components.zeekr_ev.climate import (
     async_setup_entry,
 )
 from custom_components.zeekr_ev.const import DOMAIN
+from custom_components.zeekr_ev.number import CONFIG_NUMBERS
 
 
 class MockVehicle:
@@ -29,7 +30,7 @@ class MockCoordinator:
         self.request_stats = MagicMock()
         self.request_stats.async_inc_request = AsyncMock()
         self.async_inc_invoke = AsyncMock()
-        self.ac_duration = 15
+        self.operation_durations = {vin: {"ac": 15} for vin in data}
         self.last_update_success = True
         self.vtm_locks = {}
         self._vtm_pending = {}
@@ -77,6 +78,7 @@ async def test_climate_optimistic_update():
     }
 
     coordinator = MockCoordinator(initial_data)
+    coordinator.operation_durations[vin]["ac"] = 17
     vehicle_mock = MagicMock()
     coordinator.vehicles[vin] = vehicle_mock
 
@@ -96,6 +98,10 @@ async def test_climate_optimistic_update():
     assert args[1] == "ZAF"
     assert args[2]["serviceParameters"][0]["key"] == "AC"
     assert args[2]["serviceParameters"][0]["value"] == "true"
+    assert args[2]["serviceParameters"][2] == {
+        "key": "AC.duration",
+        "value": "17",
+    }
 
     # Verify Optimistic Update
     climate_status = coordinator.data[vin]["additionalVehicleStatus"]["climateStatus"]
@@ -130,6 +136,116 @@ async def test_climate_optimistic_update():
 
     # Verify Delayed Refresh Task Created again
     assert climate.hass.async_create_task.call_count == 2
+    climate.hass.async_create_task.call_args[0][0].close()
+
+    vehicle_mock.do_remote_control.return_value = False
+    write_count = climate.async_write_ha_state.call_count
+    with pytest.raises(HomeAssistantError, match="Failed to set climate mode"):
+        await climate.async_set_hvac_mode(HVACMode.HEAT_COOL)
+    assert climate.hvac_mode == HVACMode.OFF
+    assert climate.async_write_ha_state.call_count == write_count
+    assert climate.hass.async_create_task.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_climate_set_temperature_rolls_back_on_rejection():
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"preClimateActive": "1"}}}}
+    )
+    vehicle_mock = MagicMock()
+    vehicle_mock.do_remote_control.return_value = False
+    coordinator.vehicles[vin] = vehicle_mock
+
+    climate = ZeekrClimate(coordinator, vin)
+    climate.hass = DummyHass()
+    climate.async_write_ha_state = MagicMock()
+    previous_target = climate.target_temperature
+
+    # The climate is running, so the new target is re-sent; a rejection restores the old one
+    with pytest.raises(HomeAssistantError, match="Failed to set climate mode"):
+        await climate.async_set_temperature(temperature=previous_target + 2)
+
+    params = vehicle_mock.do_remote_control.call_args.args[2]["serviceParameters"]
+    assert params[1] == {"key": "AC.temp", "value": str(previous_target + 2)}
+    assert climate.target_temperature == previous_target
+    climate.async_write_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_climate_set_temperature_rolls_back_on_request_error():
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"preClimateActive": "1"}}}}
+    )
+    vehicle_mock = MagicMock()
+    vehicle_mock.do_remote_control.side_effect = ConnectionError("boom")
+    coordinator.vehicles[vin] = vehicle_mock
+
+    climate = ZeekrClimate(coordinator, vin)
+    climate.hass = DummyHass()
+    climate.async_write_ha_state = MagicMock()
+    previous_target = climate.target_temperature
+
+    # The request itself failing (network/auth) must roll the target back too
+    with pytest.raises(ConnectionError):
+        await climate.async_set_temperature(temperature=previous_target + 2)
+
+    assert climate.target_temperature == previous_target
+    climate.async_write_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_climate_set_temperature_resends_while_running():
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"preClimateActive": "1"}}}}
+    )
+    vehicle_mock = MagicMock()
+    vehicle_mock.do_remote_control.return_value = True
+    coordinator.vehicles[vin] = vehicle_mock
+
+    climate = ZeekrClimate(coordinator, vin)
+    climate.hass = DummyHass()
+    # Simple mock for async_create_task
+    climate.hass.async_create_task = MagicMock()
+    climate.async_write_ha_state = MagicMock()
+    previous_target = climate.target_temperature
+
+    await climate.async_set_temperature(temperature=previous_target + 2)
+
+    assert climate.target_temperature == previous_target + 2
+    params = vehicle_mock.do_remote_control.call_args.args[2]["serviceParameters"]
+    assert params[1] == {"key": "AC.temp", "value": str(previous_target + 2)}
+    climate.async_write_ha_state.assert_called()
+    assert climate.hass.async_create_task.called
+    climate.hass.async_create_task.call_args[0][0].close()
+
+
+@pytest.mark.asyncio
+async def test_climate_uses_default_duration_when_unset():
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"preClimateActive": "0"}}}}
+    )
+    coordinator.operation_durations.clear()
+    vehicle_mock = MagicMock()
+    coordinator.vehicles[vin] = vehicle_mock
+
+    climate = ZeekrClimate(coordinator, vin)
+    climate.hass = DummyHass()
+    # Simple mock for async_create_task
+    climate.hass.async_create_task = MagicMock()
+    climate.async_write_ha_state = MagicMock()
+
+    await climate.async_set_hvac_mode(HVACMode.HEAT_COOL)
+
+    # Falls back to the CONFIG_NUMBERS default when the vehicle has no duration yet
+    params = vehicle_mock.do_remote_control.call_args.args[2]["serviceParameters"]
+    assert params[2] == {
+        "key": "AC.duration",
+        "value": str(CONFIG_NUMBERS["ac_operation_duration"][2]),
+    }
     climate.hass.async_create_task.call_args[0][0].close()
 
 

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -16,8 +16,6 @@ class MockCoordinator:
     def __init__(self, data):
         self.data = data
         self.vehicles = {}
-        self.seat_duration = 15
-        self.ac_duration = 15
         self.async_inc_invoke = AsyncMock()
 
     def get_vehicle_by_vin(self, vin):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,8 +1,13 @@
 import asyncio
 from math import nan
+from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
+from homeassistant.const import Platform
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import restore_state
+from homeassistant.helpers.update_coordinator import BaseCoordinatorEntity
 from custom_components.zeekr_ev.climate import ZeekrRefrigerationBoxClimate
 from custom_components.zeekr_ev.const import DOMAIN
 from custom_components.zeekr_ev.coordinator import _apply_vtm_pending
@@ -10,6 +15,7 @@ from custom_components.zeekr_ev.number import (
     ZeekrChargingLimitNumber,
     ZeekrConfigNumber,
     ZeekrRefrigerationBoxDurationNumber,
+    _migrate_legacy_config_numbers,
     async_setup_entry,
 )
 
@@ -42,7 +48,7 @@ class MockCoordinator:
         )
         self.async_inc_invoke = AsyncMock()
         self.async_request_refresh = AsyncMock()
-        self.seat_duration = 15
+        self.operation_durations = {}
         self.last_update_success = True
         self.vtm_locks = {}
         self._vtm_pending = {}
@@ -195,29 +201,218 @@ async def test_charging_limit_step():
 
 @pytest.mark.asyncio
 async def test_config_number():
-    coordinator = MockCoordinator([])
-    coordinator.seat_duration = 10
+    vehicle = MockVehicle("VIN1")
+    coordinator = MockCoordinator([vehicle])
+    coordinator.operation_durations[vehicle.vin] = {"seat": 10}
 
     number_entity = ZeekrConfigNumber(
-        coordinator, "entry_id", "seat_op", "Seat Operation", "seat_duration"
+        coordinator,
+        vehicle.vin,
+        "seat_op",
+        "Seat Operation",
+        "seat",
+        15,
     )
     number_entity.hass = DummyHass()
     number_entity.async_write_ha_state = MagicMock()
 
     # Check initial value
     assert number_entity.native_value == 10
+    assert number_entity.native_min_value == 1
+    assert number_entity.native_max_value == 60
+    assert number_entity.device_info["identifiers"] == {(DOMAIN, vehicle.vin)}
 
     # Set value
     await number_entity.async_set_native_value(5)
     assert number_entity.native_value == 5
-    assert coordinator.seat_duration == 5
+    assert coordinator.operation_durations[vehicle.vin]["seat"] == 5
     number_entity.async_write_ha_state.assert_called()
 
-    # Test async_added_to_hass with restoration
-    # Mocking async_get_last_number_data is hard because it's a mixin method
-    # But we can test that it calls super().async_added_to_hass()
-    # Since we can't easily mock the restore logic without full HA environment,
-    # we'll skip detailed restoration test but we covered the main logic logic.
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("restored", "expected"),
+    [(0, 1), (999, 60), (7.0, 7)],
+    ids=["clamped-to-min", "clamped-to-max", "in-range"],
+)
+async def test_config_number_clamps_restored_value(restored, expected):
+    vehicle = MockVehicle("VIN1")
+    coordinator = MockCoordinator([vehicle])
+
+    number_entity = ZeekrConfigNumber(
+        coordinator,
+        vehicle.vin,
+        "seat_op",
+        "Seat Operation",
+        "seat",
+        15,
+    )
+    number_entity.hass = DummyHass()
+
+    # A value stored under the old 0-15 range is clamped into the new 1-60 range
+    with patch.object(
+        BaseCoordinatorEntity, "async_added_to_hass", AsyncMock()
+    ), patch.object(
+        ZeekrConfigNumber,
+        "async_get_last_number_data",
+        AsyncMock(return_value=SimpleNamespace(native_value=restored)),
+    ):
+        await number_entity.async_added_to_hass()
+
+    assert number_entity.native_value == expected
+    assert coordinator.operation_durations[vehicle.vin]["seat"] == expected
+
+
+@pytest.mark.asyncio
+async def test_config_numbers_are_created_per_vehicle(hass, mock_config_entry):
+    coordinator = MockCoordinator([MockVehicle("VIN2"), MockVehicle("VIN1")])
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
+    async_add_entities = MagicMock()
+
+    with patch(
+        "custom_components.zeekr_ev.number._migrate_legacy_config_numbers",
+        return_value={"seat": 12},
+    ) as migrate:
+        await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    # The lowest VIN inherits the legacy entities; every vehicle is seeded with their values
+    migrate.assert_called_once_with(hass, mock_config_entry.entry_id, "VIN1")
+    config_numbers = [
+        entity
+        for entity in async_add_entities.call_args.args[0]
+        if isinstance(entity, ZeekrConfigNumber)
+    ]
+    assert {(entity.unique_id, entity.native_value) for entity in config_numbers} == {
+        ("VIN1_seat_operation_duration", 12),
+        ("VIN1_ac_operation_duration", 15),
+        ("VIN1_steering_wheel_heat_duration", 8),
+        ("VIN2_seat_operation_duration", 12),
+        ("VIN2_ac_operation_duration", 15),
+        ("VIN2_steering_wheel_heat_duration", 8),
+    }
+
+
+@pytest.mark.asyncio
+async def test_config_numbers_setup_without_legacy_entities(hass, mock_config_entry):
+    coordinator = MockCoordinator([MockVehicle("VIN1")])
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
+    async_add_entities = MagicMock()
+
+    # Unpatched: the registry seeded by conftest reports no legacy entities
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    registry = hass.data[er.DATA_REGISTRY]
+    registry.async_get_entity_id.assert_any_call(
+        Platform.NUMBER, DOMAIN, f"{mock_config_entry.entry_id}_seat_operation_duration"
+    )
+    registry.async_update_entity.assert_not_called()
+    config_numbers = [
+        entity
+        for entity in async_add_entities.call_args.args[0]
+        if isinstance(entity, ZeekrConfigNumber)
+    ]
+    assert {(entity.unique_id, entity.native_value) for entity in config_numbers} == {
+        ("VIN1_seat_operation_duration", 15),
+        ("VIN1_ac_operation_duration", 15),
+        ("VIN1_steering_wheel_heat_duration", 8),
+    }
+
+
+@pytest.mark.asyncio
+async def test_config_numbers_setup_without_vehicles(hass, mock_config_entry):
+    coordinator = MockCoordinator([])
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
+    async_add_entities = MagicMock()
+
+    with patch(
+        "custom_components.zeekr_ev.number._migrate_legacy_config_numbers"
+    ) as migrate:
+        await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    # Nothing to migrate or create for an account without cars
+    migrate.assert_not_called()
+    assert not any(
+        isinstance(entity, ZeekrConfigNumber)
+        for entity in async_add_entities.call_args.args[0]
+    )
+
+
+def _stored_state(native_value):
+    """Mimic the RestoreNumber StoredState of a legacy duration entity.
+
+    Only ``extra_data`` is modelled: the migration never reads ``.state``, because
+    RestoreNumber has always stored ``native_value`` in extra_data.
+    """
+    return SimpleNamespace(
+        extra_data=SimpleNamespace(as_dict=lambda: {"native_value": native_value}),
+    )
+
+
+def _legacy_seat_registry(hass):
+    """Make the seeded registry report one legacy seat duration entity."""
+    registry = hass.data[er.DATA_REGISTRY]
+    registry.async_get_entity_id.side_effect = lambda _domain, _platform, unique_id: (
+        "number.seat_operation_duration"
+        if unique_id == "test_entry_seat_operation_duration"
+        else None
+    )
+    return registry
+
+
+@pytest.mark.parametrize(
+    ("stored_state", "expected"),
+    [
+        (_stored_state(12), {"seat": 12}),
+        (_stored_state(0), {"seat": 1}),
+        (_stored_state(999), {"seat": 60}),
+        (_stored_state("abc"), {}),
+        # A live state is never read on its own (see _stored_state)
+        (SimpleNamespace(state=SimpleNamespace(state="7"), extra_data=None), {}),
+        (None, {}),
+    ],
+    ids=[
+        "value",
+        "clamped-to-min",
+        "clamped-to-max",
+        "non-numeric",
+        "no-extra-data",
+        "no-restore-data",
+    ],
+)
+def test_migrate_legacy_config_numbers(hass, stored_state, expected):
+    registry = _legacy_seat_registry(hass)
+    if stored_state is not None:
+        last_states = hass.data[restore_state.DATA_RESTORE_STATE].last_states
+        last_states["number.seat_operation_duration"] = stored_state
+
+    values = _migrate_legacy_config_numbers(hass, "test_entry", "VIN1")
+
+    assert values == expected
+    # The legacy entity keeps its entity_id and history under the new unique_id
+    registry.async_update_entity.assert_called_once_with(
+        "number.seat_operation_duration",
+        new_unique_id="VIN1_seat_operation_duration",
+    )
+
+
+def test_migrate_legacy_config_numbers_already_migrated(hass):
+    registry = hass.data[er.DATA_REGISTRY]
+    registry.async_get_entity_id.return_value = "number.seat_operation_duration"
+
+    values = _migrate_legacy_config_numbers(hass, "test_entry", "VIN1")
+
+    # The per-vehicle unique_ids already exist, so nothing is renamed or carried over
+    assert values == {}
+    registry.async_update_entity.assert_not_called()
+
+
+def test_migrate_legacy_config_numbers_without_legacy_entities(hass):
+    registry = hass.data[er.DATA_REGISTRY]
+
+    values = _migrate_legacy_config_numbers(hass, "test_entry", "VIN1")
+
+    assert values == {}
+    registry.async_update_entity.assert_not_called()
 
 
 def _vtm_status(active="1", temp="3.0", duration="300"):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,244 @@
+from unittest.mock import MagicMock, AsyncMock, patch
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+from custom_components.zeekr_ev.select import (
+    OPTION_LEVEL_2,
+    OPTION_OFF,
+    ZeekrSeatSelect,
+    async_setup_entry,
+)
+from custom_components.zeekr_ev.const import DOMAIN
+from custom_components.zeekr_ev.number import CONFIG_NUMBERS
+
+
+class MockVehicle:
+    def __init__(self, vin):
+        self.vin = vin
+        self.do_remote_control = MagicMock(return_value=True)
+
+
+class MockCoordinator:
+    def __init__(self, data):
+        self.data = data
+        self.vehicles = {}
+        self.async_inc_invoke = AsyncMock()
+        self.async_request_refresh = AsyncMock()
+        self.operation_durations = {vin: {"seat": 20} for vin in data}
+
+    def get_vehicle_by_vin(self, vin):
+        return self.vehicles.get(vin)
+
+
+class DummyHass:
+    def __init__(self):
+        self.data = {}
+
+    async def async_add_executor_job(self, func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+
+def _driver_seat_heat(level):
+    """Return a Driver Seat Heat select at the given level, plus its coordinator and vehicle."""
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"drvHeatSts": level}}}}
+    )
+    vehicle = MockVehicle(vin)
+    coordinator.vehicles[vin] = vehicle
+
+    select = ZeekrSeatSelect(
+        coordinator, vin, "seat_heat_driver", "Driver Seat Heat", "SH.11", "heat", ["drvHeatSts"]
+    )
+    select.hass = DummyHass()
+    # Simple mock for async_create_task
+    select.hass.async_create_task = MagicMock()
+    select.async_write_ha_state = MagicMock()
+    return select, coordinator, vehicle
+
+
+@pytest.mark.asyncio
+async def test_seat_select_level_command():
+    select, coordinator, vehicle = _driver_seat_heat(level=0)
+
+    await select.async_select_option(OPTION_LEVEL_2)
+
+    coordinator.async_inc_invoke.assert_called_once()
+    vehicle.do_remote_control.assert_called_with(
+        "start",
+        "ZAF",
+        {
+            "serviceParameters": [
+                {"key": "SH.11", "value": "true"},
+                {"key": "SH.11.level", "value": "2"},
+                {"key": "SH.11.duration", "value": "20"},
+            ]
+        }
+    )
+
+    # Verify Optimistic Update
+    assert select.current_option == OPTION_LEVEL_2
+    select.async_write_ha_state.assert_called()
+
+    # Verify Delayed Refresh Task Created instead of an immediate refresh
+    coordinator.async_request_refresh.assert_not_called()
+    select.hass.async_create_task.assert_called_once()
+    with patch("custom_components.zeekr_ev.select.asyncio.sleep", new=AsyncMock()) as sleep:
+        await select.hass.async_create_task.call_args[0][0]
+    sleep.assert_awaited_once_with(10)
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_seat_select_uses_default_duration_when_unset():
+    select, coordinator, vehicle = _driver_seat_heat(level=0)
+    coordinator.operation_durations.clear()
+
+    await select.async_select_option(OPTION_LEVEL_2)
+
+    # Falls back to the CONFIG_NUMBERS default when the vehicle has no duration yet
+    params = vehicle.do_remote_control.call_args.args[2]["serviceParameters"]
+    assert params[2] == {
+        "key": "SH.11.duration",
+        "value": str(CONFIG_NUMBERS["seat_operation_duration"][2]),
+    }
+    select.hass.async_create_task.call_args[0][0].close()
+
+
+@pytest.mark.asyncio
+async def test_seat_select_off_command():
+    select, coordinator, vehicle = _driver_seat_heat(level=2)
+
+    await select.async_select_option(OPTION_OFF)
+
+    vehicle.do_remote_control.assert_called_with(
+        "start",
+        "ZAF",
+        {
+            "serviceParameters": [
+                {"key": "SH.11", "value": "false"}
+            ]
+        }
+    )
+    assert select.current_option == OPTION_OFF
+    coordinator.async_request_refresh.assert_not_called()
+    select.hass.async_create_task.assert_called_once()
+    select.hass.async_create_task.call_args[0][0].close()
+
+
+@pytest.mark.asyncio
+async def test_seat_select_rejected_command():
+    select, coordinator, vehicle = _driver_seat_heat(level=0)
+    vehicle.do_remote_control.return_value = False
+
+    with pytest.raises(HomeAssistantError, match="Failed to set Driver Seat Heat"):
+        await select.async_select_option(OPTION_LEVEL_2)
+
+    # No optimistic update or refresh for a rejected command
+    assert select.current_option == OPTION_OFF
+    select.async_write_ha_state.assert_not_called()
+    select.hass.async_create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_seat_select_no_vehicle():
+    select, coordinator, vehicle = _driver_seat_heat(level=0)
+    coordinator.vehicles.clear()
+
+    # Should safely return without sending a command
+    await select.async_select_option(OPTION_LEVEL_2)
+
+    coordinator.async_inc_invoke.assert_not_called()
+    vehicle.do_remote_control.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_select_async_setup_entry(hass, mock_config_entry):
+    coordinator = MockCoordinator({"VIN1": {}})
+    hass.data[DOMAIN] = {mock_config_entry.entry_id: coordinator}
+
+    async_add_entities = MagicMock()
+
+    await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    assert async_add_entities.called
+    entities = async_add_entities.call_args[0][0]
+    # 4 seat heaters + 2 seat vents
+    assert len(entities) == 6
+    assert all(isinstance(e, ZeekrSeatSelect) for e in entities)
+    assert {e.unique_id for e in entities} == {
+        "VIN1_seat_heat_driver",
+        "VIN1_seat_heat_passenger",
+        "VIN1_seat_heat_rear_right",
+        "VIN1_seat_heat_rear_left",
+        "VIN1_seat_vent_driver",
+        "VIN1_seat_vent_passenger",
+    }
+
+
+def _driver_seat_vent(sts, detail):
+    """Return a Driver Seat Vent select at the given status/detail, plus its coordinator and vehicle."""
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"drvVentSts": sts, "drvVentDetail": detail}}}}
+    )
+    vehicle = MockVehicle(vin)
+    coordinator.vehicles[vin] = vehicle
+
+    select = ZeekrSeatSelect(
+        coordinator, vin, "seat_vent_driver", "Driver Seat Vent", "SV.11", "vent", ["drvVentSts", "drvVentDetail"]
+    )
+    select.hass = DummyHass()
+    # Simple mock for async_create_task
+    select.hass.async_create_task = MagicMock()
+    select.async_write_ha_state = MagicMock()
+    return select, coordinator, vehicle
+
+
+@pytest.mark.asyncio
+async def test_seat_vent_level_command():
+    # Vent status: 2 = Off, 1 = On with the level in the detail key
+    select, coordinator, vehicle = _driver_seat_vent(sts=2, detail=0)
+    assert select.current_option == OPTION_OFF
+
+    await select.async_select_option(OPTION_LEVEL_2)
+
+    vehicle.do_remote_control.assert_called_with(
+        "start",
+        "ZAF",
+        {
+            "serviceParameters": [
+                {"key": "SV.11", "value": "true"},
+                {"key": "SV.11.level", "value": "2"},
+                {"key": "SV.11.duration", "value": "20"},
+            ]
+        }
+    )
+    climate_status = coordinator.data["VIN1"]["additionalVehicleStatus"]["climateStatus"]
+    assert (climate_status["drvVentSts"], climate_status["drvVentDetail"]) == (1, 2)
+    assert select.current_option == OPTION_LEVEL_2
+    select.hass.async_create_task.call_args[0][0].close()
+
+
+@pytest.mark.asyncio
+async def test_select_properties_missing_data(hass):
+    coordinator = MockCoordinator({"VIN1": {}})
+    heat = ZeekrSeatSelect(
+        coordinator, "VIN1", "seat_heat_driver", "Driver Seat Heat", "SH.11", "heat", ["drvHeatSts"]
+    )
+    vent = ZeekrSeatSelect(
+        coordinator, "VIN1", "seat_vent_driver", "Driver Seat Vent", "SV.11", "vent", ["drvVentSts", "drvVentDetail"]
+    )
+
+    assert heat.current_option == OPTION_OFF
+    assert vent.current_option == OPTION_OFF
+
+
+@pytest.mark.asyncio
+async def test_select_device_info(hass):
+    coordinator = MockCoordinator({})
+    select = ZeekrSeatSelect(
+        coordinator, "VIN1", "seat_heat_driver", "Driver Seat Heat", "SH.11", "heat", ["drvHeatSts"]
+    )
+
+    info = select.device_info
+    assert info["identifiers"] == {(DOMAIN, "VIN1")}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,8 +1,10 @@
 from unittest.mock import MagicMock, AsyncMock, patch
 import asyncio
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 from custom_components.zeekr_ev.switch import ZeekrSwitch, async_setup_entry
 from custom_components.zeekr_ev.const import DOMAIN
+from custom_components.zeekr_ev.number import CONFIG_NUMBERS
 
 
 class MockVehicle:
@@ -19,7 +21,7 @@ class MockCoordinator:
         self.vehicles = {}
         self.async_inc_invoke = AsyncMock()
         self.async_request_refresh = AsyncMock()
-        self.steering_wheel_duration = 15
+        self.operation_durations = {vin: {"wheel": 9} for vin in data}
 
     def get_vehicle_by_vin(self, vin):
         return self.vehicles.get(vin)
@@ -261,7 +263,7 @@ async def test_steering_wheel_switch():
                 },
                 {
                     "key": "SW.duration",
-                    "value": "15"
+                    "value": "9"
                 },
                 {
                     "key": "SW.level",
@@ -292,6 +294,53 @@ async def test_steering_wheel_switch():
     # Optimistic update
     assert coordinator.data[vin]["additionalVehicleStatus"]["climateStatus"]["steerWhlHeatingSts"] == "2"
     switch.async_write_ha_state.assert_called()
+
+    vehicle_mock.do_remote_control.return_value = False
+    write_count = switch.async_write_ha_state.call_count
+    with pytest.raises(HomeAssistantError, match="Failed to turn on"):
+        await switch.async_turn_on()
+    assert switch.is_on is False
+
+    climate_status = coordinator.data[vin]["additionalVehicleStatus"]["climateStatus"]
+    climate_status["steerWhlHeatingSts"] = "1"
+    with pytest.raises(HomeAssistantError, match="Failed to turn off"):
+        await switch.async_turn_off()
+    assert switch.is_on is True
+    assert switch.async_write_ha_state.call_count == write_count
+
+
+@pytest.mark.asyncio
+async def test_steering_wheel_uses_default_duration_when_unset():
+    vin = "VIN1"
+    coordinator = MockCoordinator(
+        {vin: {"additionalVehicleStatus": {"climateStatus": {"steerWhlHeatingSts": "2"}}}}
+    )
+    coordinator.operation_durations.clear()
+    vehicle_mock = MagicMock()
+    coordinator.vehicles[vin] = vehicle_mock
+
+    switch = ZeekrSwitch(
+        coordinator,
+        vin,
+        "steering_wheel_heat",
+        "Steering Wheel Heat",
+        status_key="steerWhlHeatingSts"
+    )
+    switch.hass = DummyHass()
+    # Simple mock for async_create_task
+    switch.hass.async_create_task = MagicMock()
+    switch.async_write_ha_state = MagicMock()
+
+    await switch.async_turn_on()
+
+    # Falls back to the CONFIG_NUMBERS default when the vehicle has no duration yet
+    params = vehicle_mock.do_remote_control.call_args.args[2]["serviceParameters"]
+    assert params[1] == {
+        "key": "SW.duration",
+        "value": str(CONFIG_NUMBERS["steering_wheel_heat_duration"][2]),
+    }
+    if switch.hass.async_create_task.called:
+        switch.hass.async_create_task.call_args[0][0].close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Attach `AC Operation Duration`, `Seat Operation Duration`, and `Steering Wheel Heat Duration` to each car instead of the config entry, preventing vehicles from sharing the same values.
- Support independent durations from 1 to 60 minutes for each car.
- Use the app defaults:
  - AC: 15 minutes
  - Seats: 15 minutes
  - Steering wheel: 8 minutes
- Preserve existing account-wide values and apply them to the new per-car entities during migration.
- Surface rejected AC, seat, and steering-wheel commands as errors instead of applying an incorrect optimistic state.
- Delay the seat-state refresh by 10 seconds to prevent stale API data from reverting the displayed level.