### PR TITLE
Tidy up the Ventilate Windows button

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a custom integration for Zeekr Electric Vehicles for Home Assistant. It 
 - **Climate**: Control Heating / Cooling Vents & Seats and Steering Wheel.
 - **Sensors**: Battery Level, Range, Odometer, Interior Temperature, Tire Pressures, Charging Power, Voltage, Speed.
 - **Binary Sensors**: Charging Status, Plugged In Status, Doors, Tyre Warnings.
-- **Buttons**: Flash blinkers, enable/disable Sentry Mode.
+- **Buttons**: Flash blinkers, ventilate windows, enable/disable Sentry Mode.
 - **Locks**: Door and Trunk Lock.
 - **Device Tracker**: Location tracking.
 

--- a/custom_components/zeekr_ev/button.py
+++ b/custom_components/zeekr_ev/button.py
@@ -108,7 +108,7 @@ class ZeekrHonkFlashButton(ZeekrEntity, ButtonEntity):
 
 
 class ZeekrVentilateWindowsButton(ZeekrEntity, ButtonEntity):
-    """Button to ventilate all windows."""
+    """Button to Ventilate Windows."""
 
     _attr_icon = "mdi:weather-windy"
 
@@ -139,8 +139,10 @@ class ZeekrVentilateWindowsButton(ZeekrEntity, ButtonEntity):
         await self.hass.async_add_executor_job(
             vehicle.do_remote_control, command, service_id, setting
         )
-        await self.coordinator.async_request_refresh()
         _LOGGER.info("Window ventilation requested for vehicle %s", self.vin)
+
+        # Refresh so the window covers pick up the ventilated position
+        await self.coordinator.async_request_refresh()
 
 
 class ZeekrParkingComfortDisableButton(ZeekrEntity, ButtonEntity):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -124,7 +124,23 @@ async def test_ventilate_windows_button():
             ]
         }
     )
+    # Ventilating moves the windows, so the window covers are refreshed
     coordinator.async_request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ventilate_windows_button_no_vehicle():
+    vin = "VIN1"
+    coordinator = MockCoordinator([])
+
+    button = ZeekrVentilateWindowsButton(coordinator, vin)
+    button.hass = DummyHass()
+
+    # Should safely return without sending a command
+    await button.async_press()
+
+    coordinator.async_inc_invoke.assert_not_called()
+    coordinator.async_request_refresh.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #150:

- Class docstring mirrors the entity name like the sibling buttons.
- Log the request straight after the command, before the refresh, as the other buttons do.
- List the button in the README feature list.
- Add a no-vehicle test, matching the other platform test modules.